### PR TITLE
URL Cleanup

### DIFF
--- a/doc/reference/src/background.xml
+++ b/doc/reference/src/background.xml
@@ -84,7 +84,7 @@
       based upon well-defined strategy interfaces and non-invasive, delegating
       adapters. Spring Integration's design is inspired by the recognition of
       a strong affinity between common patterns within Spring and the
-      well-known <link ns6:href="http://www.eaipatterns.com/">Enterprise
+      well-known <link ns6:href="https://www.enterpriseintegrationpatterns.com/">Enterprise
       Integration Patterns</link> as described in the book of the same name by
       Gregor Hohpe and Bobby Woolf (Addison Wesley, 2004). Developers who have
       read that book should be immediately comfortable with the Spring

--- a/doc/reference/src/overview.xml
+++ b/doc/reference/src/overview.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "https://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 -->
 <chapter id="overview">
   <title>Spring Integration Overview</title>
@@ -39,7 +39,7 @@
       options including annotations, XML with namespace support, XML with generic "bean" elements, and of course direct
       usage of the underlying API. That API is based upon well-defined strategy interfaces and non-invasive, delegating
       adapters. Spring Integration's design is inspired by the recognition of a strong affinity between common patterns
-      within Spring and the well-known <ulink url="http://www.eaipatterns.com">Enterprise Integration Patterns</ulink>
+      within Spring and the well-known <ulink url="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</ulink>
       as described in the book of the same name by Gregor Hohpe and Bobby Woolf (Addison Wesley, 2004). Developers who
       have read that book should be immediately comfortable with the Spring Integration concepts and terminology.
 	</para>
@@ -176,7 +176,7 @@
       HTTP requests, the Message Endpoint handles Messages. Just as Controllers are mapped to URL patterns, Message
       Endpoints are mapped to Message Channels. The goal is the same in both cases: isolate application code from the
       infrastructure. These concepts are discussed at length along with all of the patterns that follow in the
-      <ulink url="http://www.eaipatterns.com">Enterprise Integration Patterns</ulink> book. Here, we provide only a
+      <ulink url="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</ulink> book. Here, we provide only a
       high-level description of the main endpoint types supported by Spring Integration and their roles. The chapters
       that follow will elaborate and provide sample code as well as configuration examples.
 	</para>

--- a/lib/net/2.0/Spring.Core.xml
+++ b/lib/net/2.0/Spring.Core.xml
@@ -565,7 +565,7 @@
             do not throw an exception, but simply make no change to the underlying collection.
             </summary>
             <remarks>Originally put into the public domain.
-            http://www.simple-talk.com/community/forums/thread/2263.aspx
+            https://www.simple-talk.com/community/forums/thread/2263.aspx
             </remarks>
             <typeparam name="TKey"></typeparam>
             <typeparam name="TValue"></typeparam>
@@ -3233,7 +3233,7 @@
             <p>
             In addition to synchronizing reads, this implementation also fixes
             IEnumerator/ICollection issue described at 
-            http://msdn.microsoft.com/en-us/netframework/aa570326.aspx
+            https://msdn.microsoft.com/en-us/netframework/aa570326.aspx
             (search for SynchronizedHashtable for issue description), by implementing 
             <see cref="T:System.Collections.IEnumerator"/> interface explicitly, and returns thread safe enumerator
             implementations as well.
@@ -36233,7 +36233,7 @@
             </p>
             <p>
             This schema is <b>typically</b> located at
-            <a href="http://www.springframework.net/xsd/spring-objects.xsd">http://www.springframework.net/xsd/spring-objects.xsd</a>.
+            <a href="https://www.springframework.net/xsd/spring-objects.xsd">https://www.springframework.net/xsd/spring-objects.xsd</a>.
             </p>
             </remarks>
             <author>Rod Johnson</author>
@@ -42436,7 +42436,7 @@
             <para>
             This method mimics the behavior of the compiler that
             automatically performs casts like int to double in "Math.Sqrt(4)".<br/>
-            See about implicit, widening type conversions on <a href="http://social.msdn.microsoft.com/Search/en-US/?query=type conversion tables">MSDN - Type Conversion Tables</a>
+            See about implicit, widening type conversions on <a href="https://social.msdn.microsoft.com/Search/en-US/?query=type conversion tables">MSDN - Type Conversion Tables</a>
             </para>
             <para>
             Note: <paramref name="targetType"/> is expected to be a value type! 
@@ -43034,7 +43034,7 @@
             will be raised by the runtime.
             <p/>Spring.Threading classes usually call this method before entering a lock block, to mirror java code
             <p>Usually this is non issue because the same exception will be raised entering the monitor 
-            associated with the lock (<seealso href="http://msdn.microsoft.com/library/default.asp?url=/library/en-us/cpref/html/frlrfsystemthreadingmonitorclassentertopic.asp"/>) 
+            associated with the lock (<seealso href="https://msdn.microsoft.com/library/default.asp?url=/library/en-us/cpref/html/frlrfsystemthreadingmonitorclassentertopic.asp"/>) 
             </p>
             </summary>
             <exception cref="T:System.Threading.ThreadInterruptedException">if the thread has been interrupted</exception>
@@ -44861,7 +44861,7 @@
             An implementation of the Java Properties class.
             </summary>
             <remarks>
-            For the complete syntax see <a href="http://java.sun.com/j2se/1.4.2/docs/api/java/util/Properties.html#load(java.io.InputStream)">java.util.Properties JavaDoc</a>.
+            For the complete syntax see <a href="https://java.sun.com/j2se/1.4.2/docs/api/java/util/Properties.html#load(java.io.InputStream)">java.util.Properties JavaDoc</a>.
             This class supports an extended syntax. There may also be sole keys on a line, in that case values are treated as <c>null</c>.
             <example>
             <code>
@@ -45055,7 +45055,7 @@
             Resolves a given <paramref name="methodInfo"/> to the <see cref="T:System.Reflection.MethodInfo"/> representing the actual implementation.
             </summary>
             <remarks>
-            see article <a href="http://weblog.ikvm.net/CommentView.aspx?guid=7356a87f-e5d7-4723-ae49-b263ab9e40ae">How To Get an Explicit Interface Implementation Method</a>.
+            see article <a href="https://weblog.ikvm.net/CommentView.aspx?guid=7356a87f-e5d7-4723-ae49-b263ab9e40ae">How To Get an Explicit Interface Implementation Method</a>.
             </remarks>
             <param name="methodInfo">a <see cref="T:System.Reflection.MethodInfo"/></param>
             <param name="implementingType">the type to lookup</param>

--- a/lib/net/2.0/Spring.Data.xml
+++ b/lib/net/2.0/Spring.Data.xml
@@ -7359,7 +7359,7 @@
                 return printGroupMappingDataSet;
              }
              </code>
-             See http://www.code-magazine.com/articleprint.aspx?quickid=0605031 for a 
+             See https://www.code-magazine.com/articleprint.aspx?quickid=0605031 for a 
              more complete discussion.
              
              </remarks>

--- a/lib/net/2.0/Spring.Services.xml
+++ b/lib/net/2.0/Spring.Services.xml
@@ -1560,7 +1560,7 @@
             Web Services Description Language (WSDL).
             </summary>
             <value>
-            The WSDL namespace of the &lt;portType&gt; element. The default value is "http://tempuri.org".
+            The WSDL namespace of the &lt;portType&gt; element. The default value is "https://www.bing.com/".
             </value>
         </member>
         <member name="P:Spring.ServiceModel.ServiceExporter.ConfigurationName">

--- a/lib/net/2.0/nunit.framework.xml
+++ b/lib/net/2.0/nunit.framework.xml
@@ -3898,7 +3898,7 @@
             <remarks>
               <para>
                 The floating point comparison code is based on this excellent article:
-                http://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm
+                https://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm
               </para>
               <para>
                 "ULP" means Unit in the Last Place and in the context of this library refers to
@@ -3936,7 +3936,7 @@
               </para>
               <para>
                 Implementation partially follows the code outlined here:
-                http://www.anttirt.net/2007/08/19/proper-floating-point-comparisons/
+                https://anttirt.net/2007/08/19/proper-floating-point-comparisons/
               </para>
             </remarks>
         </member>
@@ -3963,7 +3963,7 @@
               </para>
               <para>
                 Implementation partially follows the code outlined here:
-                http://www.anttirt.net/2007/08/19/proper-floating-point-comparisons/
+                https://anttirt.net/2007/08/19/proper-floating-point-comparisons/
               </para>
             </remarks>
         </member>

--- a/lib/net/4.0/Apache.NMS.ActiveMQ.xml
+++ b/lib/net/4.0/Apache.NMS.ActiveMQ.xml
@@ -6809,7 +6809,7 @@
         </member>
         <member name="T:Apache.NMS.ActiveMQ.OpenWire.OpenWireFormat">
             <summary>
-            Implements the <a href="http://activemq.apache.org/openwire.html">OpenWire</a> protocol.
+            Implements the <a href="https://activemq.apache.org/openwire.html">OpenWire</a> protocol.
             </summary>
         </member>
         <member name="T:Apache.NMS.ActiveMQ.Transport.IWireFormat">

--- a/lib/net/4.0/Quartz.xml
+++ b/lib/net/4.0/Quartz.xml
@@ -19125,7 +19125,7 @@
             <summary>
             A time source for Quartz.NET that returns the current time.
             Original idea by Ayende Rahien:
-            http://ayende.com/Blog/archive/2008/07/07/Dealing-with-time-in-tests.aspx
+            https://ayende.com/Blog/archive/2008/07/07/Dealing-with-time-in-tests.aspx
             </summary>
         </member>
         <member name="F:Quartz.SystemTime.UtcNow">

--- a/lib/net/4.0/Spring.Core.xml
+++ b/lib/net/4.0/Spring.Core.xml
@@ -1620,7 +1620,7 @@
             do not throw an exception, but simply make no change to the underlying collection.
             </summary>
             <remarks>Originally put into the public domain.
-            http://www.simple-talk.com/community/forums/thread/2263.aspx
+            https://www.simple-talk.com/community/forums/thread/2263.aspx
             </remarks>
             <typeparam name="TKey"></typeparam>
             <typeparam name="TValue"></typeparam>
@@ -4210,7 +4210,7 @@
             <p>
             In addition to synchronizing reads, this implementation also fixes
             IEnumerator/ICollection issue described at 
-            http://msdn.microsoft.com/en-us/netframework/aa570326.aspx
+            https://msdn.microsoft.com/en-us/netframework/aa570326.aspx
             (search for SynchronizedHashtable for issue description), by implementing 
             <see cref="T:System.Collections.IEnumerator"/> interface explicitly, and returns thread safe enumerator
             implementations as well.
@@ -37748,7 +37748,7 @@
             </p>
             <p>
             This schema is <b>typically</b> located at
-            <a href="http://www.springframework.net/xsd/spring-objects.xsd">http://www.springframework.net/xsd/spring-objects.xsd</a>.
+            <a href="https://www.springframework.net/xsd/spring-objects.xsd">https://www.springframework.net/xsd/spring-objects.xsd</a>.
             </p>
             </remarks>
             <author>Rod Johnson</author>
@@ -43784,7 +43784,7 @@
             <para>
             This method mimics the behavior of the compiler that
             automatically performs casts like int to double in "Math.Sqrt(4)".<br/>
-            See about implicit, widening type conversions on <a href="http://social.msdn.microsoft.com/Search/en-US/?query=type conversion tables">MSDN - Type Conversion Tables</a>
+            See about implicit, widening type conversions on <a href="https://social.msdn.microsoft.com/Search/en-US/?query=type conversion tables">MSDN - Type Conversion Tables</a>
             </para>
             <para>
             Note: <paramref name="targetType"/> is expected to be a value type! 
@@ -44382,7 +44382,7 @@
             will be raised by the runtime.
             <p/>Spring.Threading classes usually call this method before entering a lock block, to mirror java code
             <p>Usually this is non issue because the same exception will be raised entering the monitor 
-            associated with the lock (<seealso href="http://msdn.microsoft.com/library/default.asp?url=/library/en-us/cpref/html/frlrfsystemthreadingmonitorclassentertopic.asp"/>) 
+            associated with the lock (<seealso href="https://msdn.microsoft.com/library/default.asp?url=/library/en-us/cpref/html/frlrfsystemthreadingmonitorclassentertopic.asp"/>) 
             </p>
             </summary>
             <exception cref="T:System.Threading.ThreadInterruptedException">if the thread has been interrupted</exception>
@@ -46234,7 +46234,7 @@
             An implementation of the Java Properties class.
             </summary>
             <remarks>
-            For the complete syntax see <a href="http://java.sun.com/j2se/1.4.2/docs/api/java/util/Properties.html#load(java.io.InputStream)">java.util.Properties JavaDoc</a>.
+            For the complete syntax see <a href="https://java.sun.com/j2se/1.4.2/docs/api/java/util/Properties.html#load(java.io.InputStream)">java.util.Properties JavaDoc</a>.
             This class supports an extended syntax. There may also be sole keys on a line, in that case values are treated as <c>null</c>.
             <example>
             <code>
@@ -46428,7 +46428,7 @@
             Resolves a given <paramref name="methodInfo"/> to the <see cref="T:System.Reflection.MethodInfo"/> representing the actual implementation.
             </summary>
             <remarks>
-            see article <a href="http://weblog.ikvm.net/CommentView.aspx?guid=7356a87f-e5d7-4723-ae49-b263ab9e40ae">How To Get an Explicit Interface Implementation Method</a>.
+            see article <a href="https://weblog.ikvm.net/CommentView.aspx?guid=7356a87f-e5d7-4723-ae49-b263ab9e40ae">How To Get an Explicit Interface Implementation Method</a>.
             </remarks>
             <param name="methodInfo">a <see cref="T:System.Reflection.MethodInfo"/></param>
             <param name="implementingType">the type to lookup</param>

--- a/lib/net/4.0/Spring.Data.xml
+++ b/lib/net/4.0/Spring.Data.xml
@@ -7521,7 +7521,7 @@
                 return printGroupMappingDataSet;
              }
              </code>
-             See http://www.code-magazine.com/articleprint.aspx?quickid=0605031 for a 
+             See https://www.code-magazine.com/articleprint.aspx?quickid=0605031 for a 
              more complete discussion.
              
              </remarks>

--- a/lib/net/4.0/Spring.Services.xml
+++ b/lib/net/4.0/Spring.Services.xml
@@ -1669,7 +1669,7 @@
             Web Services Description Language (WSDL).
             </summary>
             <value>
-            The WSDL namespace of the &lt;portType&gt; element. The default value is "http://tempuri.org".
+            The WSDL namespace of the &lt;portType&gt; element. The default value is "https://www.bing.com/".
             </value>
         </member>
         <member name="P:Spring.ServiceModel.ServiceExporter.ConfigurationName">

--- a/lib/net/4.0/nunit.framework.xml
+++ b/lib/net/4.0/nunit.framework.xml
@@ -3534,7 +3534,7 @@
             <remarks>
               <para>
                 The floating point comparison code is based on this excellent article:
-                http://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm
+                https://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm
               </para>
               <para>
                 "ULP" means Unit in the Last Place and in the context of this library refers to
@@ -3572,7 +3572,7 @@
               </para>
               <para>
                 Implementation partially follows the code outlined here:
-                http://www.anttirt.net/2007/08/19/proper-floating-point-comparisons/
+                https://anttirt.net/2007/08/19/proper-floating-point-comparisons/
               </para>
             </remarks>
         </member>
@@ -3599,7 +3599,7 @@
               </para>
               <para>
                 Implementation partially follows the code outlined here:
-                http://www.anttirt.net/2007/08/19/proper-floating-point-comparisons/
+                https://anttirt.net/2007/08/19/proper-floating-point-comparisons/
               </para>
             </remarks>
         </member>

--- a/tools/nant/NAnt.CompressionTasks.xml
+++ b/tools/nant/NAnt.CompressionTasks.xml
@@ -80,7 +80,7 @@
             Creates a tar file from the specified filesets.
             </summary>
             <remarks>
-              <para>Uses <see href="http://www.icsharpcode.net/OpenSource/SharpZipLib/">#ziplib</see> (SharpZipLib), an open source Tar/Zip/GZip library written entirely in C#.</para>
+              <para>Uses <see href="Default.aspx">#ziplib</see> (SharpZipLib), an open source Tar/Zip/GZip library written entirely in C#.</para>
             </remarks>
             <example>
               <para>
@@ -133,7 +133,7 @@
             </summary>
             <remarks>
               <para>
-              Uses <see href="http://www.icsharpcode.net/OpenSource/SharpZipLib/">#ziplib</see>
+              Uses <see href="Default.aspx">#ziplib</see>
               (SharpZipLib), an open source Zip/GZip library written entirely in C#.
               </para>
             </remarks>
@@ -173,7 +173,7 @@
             </summary>
             <remarks>
               <para>
-              Uses <see href="http://www.icsharpcode.net/OpenSource/SharpZipLib/">#ziplib</see>
+              Uses <see href="Default.aspx">#ziplib</see>
               (SharpZipLib), an open source Zip/GZip library written entirely in C#.
               </para>
             </remarks>
@@ -214,7 +214,7 @@
             </summary>
             <remarks>
               <para>
-              Uses <see href="http://www.icsharpcode.net/OpenSource/SharpZipLib/">#ziplib</see>
+              Uses <see href="Default.aspx">#ziplib</see>
               (SharpZipLib), an open source Tar/Zip/GZip library written entirely in C#.
               </para>
             </remarks>

--- a/tools/nant/NAnt.Core.xml
+++ b/tools/nant/NAnt.Core.xml
@@ -6245,7 +6245,7 @@
               </para>
               <code>
                 <![CDATA[
-            <get src="http://nant.sourceforge.org/" dest="help/index.html" />
+            <get src="https://nant.sourceforge.org/" dest="help/index.html" />
                 ]]>
               </code>
             </example>
@@ -6256,7 +6256,7 @@
               </para>
               <code>
                 <![CDATA[
-            <get src="http://password.protected.site/index.html" dest="secure/index.html">
+            <get src="https://password.protected.site/index.html" dest="secure/index.html">
                 <credentials username="user" password="guess" domain="mydomain" />
                 <proxy host="proxy.company.com" port="8080">
                     <credentials username="proxyuser" password="dunno" />
@@ -7493,7 +7493,7 @@
             <remarks>
             <para>
             The <see cref="P:NAnt.Core.Tasks.RegexTask.Pattern"/> attribute must contain one or more 
-            <see href="http://msdn.microsoft.com/library/default.asp?url=/library/en-us/cpgenref/html/cpcongroupingconstructs.asp">
+            <see href="https://msdn.microsoft.com/library/default.asp?url=/library/en-us/cpgenref/html/cpcongroupingconstructs.asp">
             named grouping constructs</see>, which represents the names of the 
             properties to be set. These named grouping constructs can be enclosed 
             by angle brackets (?&lt;name&gt;) or single quotes (?'name').
@@ -8067,7 +8067,7 @@
               The date and time string displayed by the <see cref="T:NAnt.Core.Tasks.TStampTask"/> 
               uses the computer's default long date and time string format.  You 
               might consider setting these to the 
-              <see href="http://www.cl.cam.ac.uk/~mgk25/iso-time.html">ISO 8601 standard 
+              <see href="https://www.cl.cam.ac.uk/~mgk25/iso-time.html">ISO 8601 standard 
               for date and time notation</see>.
               </para>
             </remarks>
@@ -13423,7 +13423,7 @@
         </member>
         <member name="F:NAnt.Core.FrameworkTypes.Mono">
             <summary>
-            Frameworks released as part of the open-source <see href="http://www.mono-project.com">Mono</see>
+            Frameworks released as part of the open-source <see href="https://www.mono-project.com">Mono</see>
             project.
             </summary>
         </member>

--- a/tools/nant/NAnt.DotNetTasks.xml
+++ b/tools/nant/NAnt.DotNetTasks.xml
@@ -2744,7 +2744,7 @@
              </example>
              <example>
                <para>
-               Define a custom function and call it using <see href="http://boo.codehaus.org/">Boo</see>.
+               Define a custom function and call it using <see href="https://boo.codehaus.org/">Boo</see>.
                </para>
                <code>
                      &lt;script language="Boo.CodeDom.BooCodeProvider, Boo.CodeDom, Version=1.0.0.0, Culture=neutral, PublicKeyToken=32c39770e9a21a67"

--- a/tools/nant/NAnt.NUnit1Tasks.xml
+++ b/tools/nant/NAnt.NUnit1Tasks.xml
@@ -175,7 +175,7 @@
             </summary>
             <remarks>
               <para>
-              See the <see href="http://nunit.sf.net">NUnit home page</see> for more 
+              See the <see href="http://nunit.sourceforge.net/">NUnit home page</see> for more 
               information.
               </para>
               <para>

--- a/tools/nant/NAnt.NUnit2Tasks.xml
+++ b/tools/nant/NAnt.NUnit2Tasks.xml
@@ -259,7 +259,7 @@
                 ]]>
               </code>
               <para>
-              See the <see href="http://nunit.sf.net">NUnit home page</see> for more 
+              See the <see href="http://nunit.sourceforge.net/">NUnit home page</see> for more 
               information.
               </para>
             </remarks>

--- a/tools/nunit/net-2.0/framework/nunit.framework.xml
+++ b/tools/nunit/net-2.0/framework/nunit.framework.xml
@@ -3898,7 +3898,7 @@
             <remarks>
               <para>
                 The floating point comparison code is based on this excellent article:
-                http://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm
+                https://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm
               </para>
               <para>
                 "ULP" means Unit in the Last Place and in the context of this library refers to
@@ -3936,7 +3936,7 @@
               </para>
               <para>
                 Implementation partially follows the code outlined here:
-                http://www.anttirt.net/2007/08/19/proper-floating-point-comparisons/
+                https://anttirt.net/2007/08/19/proper-floating-point-comparisons/
               </para>
             </remarks>
         </member>
@@ -3963,7 +3963,7 @@
               </para>
               <para>
                 Implementation partially follows the code outlined here:
-                http://www.anttirt.net/2007/08/19/proper-floating-point-comparisons/
+                https://anttirt.net/2007/08/19/proper-floating-point-comparisons/
               </para>
             </remarks>
         </member>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://gee.cs.oswego.edu/dl/ (200) with 2 occurrences could not be migrated:  
   ([https](https://gee.cs.oswego.edu/dl/) result AnnotatedConnectException).
* http://nant.sourceforge.net (200) with 2 occurrences could not be migrated:  
   ([https](https://nant.sourceforge.net) result AnnotatedConnectException).
* http://ndoc.sourceforge.net/ (200) with 1 occurrences could not be migrated:  
   ([https](https://ndoc.sourceforge.net/) result AnnotatedConnectException).
* http://netcommon.sourceforge.net/ (200) with 2 occurrences could not be migrated:  
   ([https](https://netcommon.sourceforge.net/) result AnnotatedConnectException).
* http://nunit.sf.net (301) with 2 occurrences could not be migrated:  
   ([https](https://nunit.sf.net) result AnnotatedConnectException).
* http://tempuri.org/nant-donotuse.xsd (404) with 1 occurrences could not be migrated:  
   ([https](https://tempuri.org/nant-donotuse.xsd) result ConnectTimeoutException).
* http://tempuri.org/nant.xsd (404) with 1 occurrences could not be migrated:  
   ([https](https://tempuri.org/nant.xsd) result ConnectTimeoutException).
* http://www.mycompany.com/resource.txt (404) with 2 occurrences could not be migrated:  
   ([https](https://www.mycompany.com/resource.txt) result ConnectTimeoutException).
* http://www.mycompany.com/services.txt (404) with 4 occurrences could not be migrated:  
   ([https](https://www.mycompany.com/services.txt) result ConnectTimeoutException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.icsharpcode.net/OpenSource/SharpZipLib/ (302) with 4 occurrences migrated to:  
  Default.aspx ([https](https://www.icsharpcode.net/OpenSource/SharpZipLib/) result IllegalArgumentException).
* http://www.anttirt.net/2007/08/19/proper-floating-point-comparisons/ (301) with 6 occurrences migrated to:  
  https://anttirt.net/2007/08/19/proper-floating-point-comparisons/ ([https](https://www.anttirt.net/2007/08/19/proper-floating-point-comparisons/) result SSLHandshakeException).
* http://boo.codehaus.org/ (UnknownHostException) with 1 occurrences migrated to:  
  https://boo.codehaus.org/ ([https](https://boo.codehaus.org/) result UnknownHostException).
* http://nant.sourceforge.org/ (UnknownHostException) with 1 occurrences migrated to:  
  https://nant.sourceforge.org/ ([https](https://nant.sourceforge.org/) result UnknownHostException).
* http://password.protected.site/index.html (UnknownHostException) with 1 occurrences migrated to:  
  https://password.protected.site/index.html ([https](https://password.protected.site/index.html) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://activemq.apache.org/openwire.html with 1 occurrences migrated to:  
  https://activemq.apache.org/openwire.html ([https](https://activemq.apache.org/openwire.html) result 200).
* http://social.msdn.microsoft.com/Search/en-US/?query=type with 2 occurrences migrated to:  
  https://social.msdn.microsoft.com/Search/en-US/?query=type ([https](https://social.msdn.microsoft.com/Search/en-US/?query=type) result 200).
* http://weblog.ikvm.net/CommentView.aspx?guid=7356a87f-e5d7-4723-ae49-b263ab9e40ae with 2 occurrences migrated to:  
  https://weblog.ikvm.net/CommentView.aspx?guid=7356a87f-e5d7-4723-ae49-b263ab9e40ae ([https](https://weblog.ikvm.net/CommentView.aspx?guid=7356a87f-e5d7-4723-ae49-b263ab9e40ae) result 200).
* http://tempuri.org (302) with 2 occurrences migrated to:  
  https://www.bing.com/ ([https](https://tempuri.org) result 200).
* http://www.cl.cam.ac.uk/~mgk25/iso-time.html with 1 occurrences migrated to:  
  https://www.cl.cam.ac.uk/~mgk25/iso-time.html ([https](https://www.cl.cam.ac.uk/~mgk25/iso-time.html) result 200).
* http://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm with 3 occurrences migrated to:  
  https://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm ([https](https://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm) result 200).
* http://www.eaipatterns.com (302) with 2 occurrences migrated to:  
  https://www.enterpriseintegrationpatterns.com/ ([https](https://www.eaipatterns.com) result 200).
* http://www.eaipatterns.com/ (302) with 1 occurrences migrated to:  
  https://www.enterpriseintegrationpatterns.com/ ([https](https://www.eaipatterns.com/) result 200).
* http://www.mono-project.com with 1 occurrences migrated to:  
  https://www.mono-project.com ([https](https://www.mono-project.com) result 200).
* http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd with 1 occurrences migrated to:  
  https://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd ([https](https://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd) result 200).
* http://www.springframework.net/xsd/spring-objects.xsd with 4 occurrences migrated to:  
  https://www.springframework.net/xsd/spring-objects.xsd ([https](https://www.springframework.net/xsd/spring-objects.xsd) result 200).
* http://ayende.com/Blog/archive/2008/07/07/Dealing-with-time-in-tests.aspx with 1 occurrences migrated to:  
  https://ayende.com/Blog/archive/2008/07/07/Dealing-with-time-in-tests.aspx ([https](https://ayende.com/Blog/archive/2008/07/07/Dealing-with-time-in-tests.aspx) result 301).
* http://msdn.microsoft.com/en-us/netframework/aa570326.aspx with 2 occurrences migrated to:  
  https://msdn.microsoft.com/en-us/netframework/aa570326.aspx ([https](https://msdn.microsoft.com/en-us/netframework/aa570326.aspx) result 301).
* http://msdn.microsoft.com/library/default.asp?url=/library/en-us/cpgenref/html/cpcongroupingconstructs.asp with 1 occurrences migrated to:  
  https://msdn.microsoft.com/library/default.asp?url=/library/en-us/cpgenref/html/cpcongroupingconstructs.asp ([https](https://msdn.microsoft.com/library/default.asp?url=/library/en-us/cpgenref/html/cpcongroupingconstructs.asp) result 301).
* http://msdn.microsoft.com/library/default.asp?url=/library/en-us/cpref/html/frlrfsystemthreadingmonitorclassentertopic.asp with 2 occurrences migrated to:  
  https://msdn.microsoft.com/library/default.asp?url=/library/en-us/cpref/html/frlrfsystemthreadingmonitorclassentertopic.asp ([https](https://msdn.microsoft.com/library/default.asp?url=/library/en-us/cpref/html/frlrfsystemthreadingmonitorclassentertopic.asp) result 301).
* http://www.code-magazine.com/articleprint.aspx?quickid=0605031 with 2 occurrences migrated to:  
  https://www.code-magazine.com/articleprint.aspx?quickid=0605031 ([https](https://www.code-magazine.com/articleprint.aspx?quickid=0605031) result 301).
* http://www.simple-talk.com/community/forums/thread/2263.aspx with 2 occurrences migrated to:  
  https://www.simple-talk.com/community/forums/thread/2263.aspx ([https](https://www.simple-talk.com/community/forums/thread/2263.aspx) result 301).
* http://java.sun.com/j2se/1.4.2/docs/api/java/util/Properties.html with 2 occurrences migrated to:  
  https://java.sun.com/j2se/1.4.2/docs/api/java/util/Properties.html ([https](https://java.sun.com/j2se/1.4.2/docs/api/java/util/Properties.html) result 302).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 5 occurrences
* http://docbook.org/ns/docbook/xi with 1 occurrences
* http://localhost/A/A.csproj with 2 occurrences
* http://localhost/B with 1 occurrences
* http://localhost/B/ with 1 occurrences
* http://www.gordic.cz/shared/project-config/v_1.0.0.0 with 2 occurrences
* http://www.springframework.net with 66 occurrences
* http://www.springframework.net/ with 6 occurrences
* http://www.springframework.net/integration with 60 occurrences
* http://www.springframework.net/integration/nms with 21 occurrences
* http://www.springframework.net/si/doc-latest/reference/html/index.html with 1 occurrences
* http://www.w3.org/1998/Math/MathML with 2 occurrences
* http://www.w3.org/1999/xhtml with 2 occurrences
* http://www.w3.org/1999/xlink with 3 occurrences
* http://www.w3.org/2000/svg with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 2 occurrences