### PR TITLE
URL Cleanup

### DIFF
--- a/doc/reference/src/background.xml
+++ b/doc/reference/src/background.xml
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/src/quickstarts.xml
+++ b/doc/reference/src/quickstarts.xml
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Spring/Spring.Integration.Example/Spring.Integration.Example.HelloWorld/HelloService.cs
+++ b/examples/Spring/Spring.Integration.Example/Spring.Integration.Example.HelloWorld/HelloService.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Spring/Spring.Integration.Example/Spring.Integration.Example.HelloWorld/Program.cs
+++ b/examples/Spring/Spring.Integration.Example/Spring.Integration.Example.HelloWorld/Program.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Spring/Spring.Integration.Example/Spring.Integration.Example.IntervalOddEven/Counter.cs
+++ b/examples/Spring/Spring.Integration.Example/Spring.Integration.Example.IntervalOddEven/Counter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Spring/Spring.Integration.Example/Spring.Integration.Example.IntervalOddEven/EvenLogger.cs
+++ b/examples/Spring/Spring.Integration.Example/Spring.Integration.Example.IntervalOddEven/EvenLogger.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Spring/Spring.Integration.Example/Spring.Integration.Example.IntervalOddEven/OddLogger.cs
+++ b/examples/Spring/Spring.Integration.Example/Spring.Integration.Example.IntervalOddEven/OddLogger.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Spring/Spring.Integration.Example/Spring.Integration.Example.IntervalOddEven/ParityResolver.cs
+++ b/examples/Spring/Spring.Integration.Example/Spring.Integration.Example.IntervalOddEven/ParityResolver.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/Spring/Spring.Integration.Example/Spring.Integration.Example.IntervalOddEven/Program.cs
+++ b/examples/Spring/Spring.Integration.Example/Spring.Integration.Example.IntervalOddEven/Program.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration.Nms/Nms/AbstractNmsTemplateBasedAdapter.cs
+++ b/src/Spring/Spring.Integration.Nms/Nms/AbstractNmsTemplateBasedAdapter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration.Nms/Nms/ChannelPublishingJmsMessageListener.cs
+++ b/src/Spring/Spring.Integration.Nms/Nms/ChannelPublishingJmsMessageListener.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration.Nms/Nms/Config/NmsAdapterParserUtils.cs
+++ b/src/Spring/Spring.Integration.Nms/Nms/Config/NmsAdapterParserUtils.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration.Nms/Nms/Config/NmsInboundChannelAdapterParser.cs
+++ b/src/Spring/Spring.Integration.Nms/Nms/Config/NmsInboundChannelAdapterParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration.Nms/Nms/Config/NmsMessageDrivenEndpointParser.cs
+++ b/src/Spring/Spring.Integration.Nms/Nms/Config/NmsMessageDrivenEndpointParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration.Nms/Nms/Config/NmsNamespaceParser.cs
+++ b/src/Spring/Spring.Integration.Nms/Nms/Config/NmsNamespaceParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration.Nms/Nms/Config/NmsOutboundChannelAdapterParser.cs
+++ b/src/Spring/Spring.Integration.Nms/Nms/Config/NmsOutboundChannelAdapterParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration.Nms/Nms/Config/NmsOutboundGatewayParser.cs
+++ b/src/Spring/Spring.Integration.Nms/Nms/Config/NmsOutboundGatewayParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration.Nms/Nms/DefaultNmsHeaderMapper.cs
+++ b/src/Spring/Spring.Integration.Nms/Nms/DefaultNmsHeaderMapper.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration.Nms/Nms/HeaderMappingMessageConverter.cs
+++ b/src/Spring/Spring.Integration.Nms/Nms/HeaderMappingMessageConverter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration.Nms/Nms/INmsHeaderMapper.cs
+++ b/src/Spring/Spring.Integration.Nms/Nms/INmsHeaderMapper.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration.Nms/Nms/NmsDestinationPollingSource.cs
+++ b/src/Spring/Spring.Integration.Nms/Nms/NmsDestinationPollingSource.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration.Nms/Nms/NmsHeaders.cs
+++ b/src/Spring/Spring.Integration.Nms/Nms/NmsHeaders.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration.Nms/Nms/NmsMessageDrivenEndpoint.cs
+++ b/src/Spring/Spring.Integration.Nms/Nms/NmsMessageDrivenEndpoint.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration.Nms/Nms/NmsOutboundGateway.cs
+++ b/src/Spring/Spring.Integration.Nms/Nms/NmsOutboundGateway.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration.Nms/Nms/NmsSendingMessageHandler.cs
+++ b/src/Spring/Spring.Integration.Nms/Nms/NmsSendingMessageHandler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Adapter/AbstractRemotingOutboundGateway.cs
+++ b/src/Spring/Spring.Integration/Adapter/AbstractRemotingOutboundGateway.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Adapter {
     /// A base class for outbound Messaging Gateways that use url-based remoting.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class AbstractRemotingOutboundGateway : AbstractReplyProducingMessageHandler {
 
         private readonly IRemoteMessageHandler _handlerProxy;

--- a/src/Spring/Spring.Integration/Adapter/Config/AbstractRemotingGatewayParser.cs
+++ b/src/Spring/Spring.Integration/Adapter/Config/AbstractRemotingGatewayParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +30,7 @@ namespace Spring.Integration.Adapter.Config {
     /// Base class for remoting gateway parsers.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class AbstractRemotingGatewayParser : AbstractSimpleObjectDefinitionParser {
 
         protected override string ResolveId(XmlElement element, AbstractObjectDefinition definition, ParserContext parserContext) {

--- a/src/Spring/Spring.Integration/Adapter/Config/AbstractRemotingOutboundGatewayParser.cs
+++ b/src/Spring/Spring.Integration/Adapter/Config/AbstractRemotingOutboundGatewayParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Adapter.Config {
     /// Base class for url-based remoting outbound gateway parsers. 
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class AbstractRemotingOutboundGatewayParser : AbstractConsumerEndpointParser {
 
         protected abstract string GetGatewayClassName(XmlElement element);

--- a/src/Spring/Spring.Integration/Adapter/IRemoteMessageHandler.cs
+++ b/src/Spring/Spring.Integration/Adapter/IRemoteMessageHandler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ namespace Spring.Integration.Adapter {
     /// Enables serializable Messages to be exchanged across a remote invocation.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface IRemoteMessageHandler {
 
         IMessage Handle(IMessage message);

--- a/src/Spring/Spring.Integration/Adapter/MessageMappingException.cs
+++ b/src/Spring/Spring.Integration/Adapter/MessageMappingException.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ namespace Spring.Integration.Adapter {
     /// Exception that indicates an error during message mapping.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MessageMappingException : MessagingException {
 
         public MessageMappingException(string description, Exception innerException)

--- a/src/Spring/Spring.Integration/Adapter/RemotingInboundGatewaySupport.cs
+++ b/src/Spring/Spring.Integration/Adapter/RemotingInboundGatewaySupport.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ namespace Spring.Integration.Adapter {
     /// Support class for inbound Messaging Gateways.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class RemotingInboundGatewaySupport : SimpleMessagingGateway, IRemoteMessageHandler {
 
         private volatile bool _expectReply = true;

--- a/src/Spring/Spring.Integration/Aggregator/AbstractMessageAggregator.cs
+++ b/src/Spring/Spring.Integration/Aggregator/AbstractMessageAggregator.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -44,7 +44,7 @@ namespace Spring.Integration.Aggregator {
     /// </summary>
     /// <author>Mark Fisher</author>
     /// <author>Marius Bogoevici</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class AbstractMessageAggregator : AbstractMessageBarrierHandler<IDictionary<object, IMessage>, object> {
 
         private volatile ICompletionStrategy _completionStrategy = new SequenceSizeCompletionStrategy();

--- a/src/Spring/Spring.Integration/Aggregator/AbstractMessageBarrierHandler.cs
+++ b/src/Spring/Spring.Integration/Aggregator/AbstractMessageBarrierHandler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -61,7 +61,7 @@ namespace Spring.Integration.Aggregator {
     /// </summary>
     /// <author>Mark Fisher</author>
     /// <author>Marius Bogoevici</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class AbstractMessageBarrierHandler<T, K> : AbstractMessageHandler, IObjectFactoryAware, IInitializingObject where T : IDictionary<K, IMessage> {
 
         public static TimeSpan DEFAULT_SEND_TIMEOUT = TimeSpan.FromMilliseconds(1000);

--- a/src/Spring/Spring.Integration/Aggregator/CompletionStrategyAdapter.cs
+++ b/src/Spring/Spring.Integration/Aggregator/CompletionStrategyAdapter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ namespace Spring.Integration.Aggregator {
     /// attribute (e.g. &lt;completion-strategy ref="beanReference" method="methodName"/&gt;).
     /// </summary>
     /// <author>Marius Bogoevici</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class CompletionStrategyAdapter : MessageListMethodAdapter, ICompletionStrategy {
 
         public CompletionStrategyAdapter(object obj, MethodInfo method)

--- a/src/Spring/Spring.Integration/Aggregator/ICompletionStrategy.cs
+++ b/src/Spring/Spring.Integration/Aggregator/ICompletionStrategy.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ namespace Spring.Integration.Aggregator {
     /// completion (i.e. can trip a barrier).
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface ICompletionStrategy {
 
         /// <summary>

--- a/src/Spring/Spring.Integration/Aggregator/MessageBarrier.cs
+++ b/src/Spring/Spring.Integration/Aggregator/MessageBarrier.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -35,7 +35,7 @@ namespace Spring.Integration.Aggregator {
     /// This class is not thread-safe and will be synchronized by the calling code.
     /// </summary>
     /// <author>Marius Bogoevici</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MessageBarrier<T, K> where T : IDictionary<K, IMessage> {
 
         protected T _messages;

--- a/src/Spring/Spring.Integration/Aggregator/MessageListMethodAdapter.cs
+++ b/src/Spring/Spring.Integration/Aggregator/MessageListMethodAdapter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ namespace Spring.Integration.Aggregator {
     /// list of {@link Message Message} instances or payloads.
     /// </summary>
     /// <author>Marius Bogoevici</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MessageListMethodAdapter {
 
         private DefaultMethodInvoker _invoker;

--- a/src/Spring/Spring.Integration/Aggregator/MessageSequenceComparator.cs
+++ b/src/Spring/Spring.Integration/Aggregator/MessageSequenceComparator.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ namespace Spring.Integration.Aggregator {
     /// property of a {@link Message Message's} header.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MessageSequenceComparator : IComparer<IMessage> {
 
         public int Compare(IMessage message1, IMessage message2) {

--- a/src/Spring/Spring.Integration/Aggregator/MethodInvokingAggregator.cs
+++ b/src/Spring/Spring.Integration/Aggregator/MethodInvokingAggregator.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,7 +36,7 @@ namespace Spring.Integration.Aggregator {
     /// </summary>
     /// <author>Marius Bogoevici</author>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MethodInvokingAggregator : AbstractMessageAggregator {
 
         private readonly MessageListMethodAdapter _methodInvoker;

--- a/src/Spring/Spring.Integration/Aggregator/Resequencer.cs
+++ b/src/Spring/Spring.Integration/Aggregator/Resequencer.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -37,7 +37,7 @@ namespace Spring.Integration.Aggregator {
     /// apply here as well.
     /// </summary>
     /// <author>Marius Bogoevici</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class Resequencer : AbstractMessageBarrierHandler<SortedDictionary<int, IMessage>, int> {
 
         private volatile bool _releasePartialSequences = true;

--- a/src/Spring/Spring.Integration/Aggregator/SequenceSizeCompletionStrategy.cs
+++ b/src/Spring/Spring.Integration/Aggregator/SequenceSizeCompletionStrategy.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Aggregator {
     /// </summary>
     /// <author>Mark Fisher</author>
     /// <author>Marius Bogoevici</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class SequenceSizeCompletionStrategy : ICompletionStrategy {
 
         public bool IsComplete(IList<IMessage> messages) {

--- a/src/Spring/Spring.Integration/Attributes/AggregatorAttribute.cs
+++ b/src/Spring/Spring.Integration/Attributes/AggregatorAttribute.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ namespace Spring.Integration.Attributes {
     /// Message or a single Object to be used as a Message payload.
     /// </summary>
     /// <author>Marius Bogoevici</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [AttributeUsage(AttributeTargets.Method)]
     public class AggregatorAttribute : Attribute {
         private string _inputChannel = "";

--- a/src/Spring/Spring.Integration/Attributes/CompletionStrategyAttribute.cs
+++ b/src/Spring/Spring.Integration/Attributes/CompletionStrategyAttribute.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ namespace Spring.Integration.Attributes {
     /// payload objects is complete.
     /// </summary>
     /// <author>Marius Bogoevici</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [AttributeUsage(AttributeTargets.Method)]
     public class CompletionStrategyAttribute : Attribute {
 

--- a/src/Spring/Spring.Integration/Attributes/GatewayAttribute.cs
+++ b/src/Spring/Spring.Integration/Attributes/GatewayAttribute.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -42,7 +42,7 @@ namespace Spring.Integration.Attributes {
     /// the return value if necessary.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [AttributeUsage(AttributeTargets.Method)]
     public class GatewayAttribute : Attribute {
         private string _requestChannel;

--- a/src/Spring/Spring.Integration/Attributes/HeaderAttribute.cs
+++ b/src/Spring/Spring.Integration/Attributes/HeaderAttribute.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Attributes {
     /// the header. The default value for 'required' is <code>true</code>.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// /// <author>Andreas Döhring (.NET)</author>
+    /// /// <author>Andreas Dï¿½hring (.NET)</author>
     [AttributeUsage(AttributeTargets.Parameter)]
     public class HeaderAttribute : Attribute {
         private bool _required = true;

--- a/src/Spring/Spring.Integration/Attributes/HeadersAttribute.cs
+++ b/src/Spring/Spring.Integration/Attributes/HeadersAttribute.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ namespace Spring.Integration.Attributes {
     /// {@link java.util.Map}, and all of the Map's keys must be Strings.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [AttributeUsage(AttributeTargets.Parameter)]
     public class HeadersAttribute : Attribute {
     }

--- a/src/Spring/Spring.Integration/Attributes/MessageEndpoint.cs
+++ b/src/Spring/Spring.Integration/Attributes/MessageEndpoint.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ namespace Spring.Integration.Attributes {
     /// Message Endpoint.
     /// </summary>
     /// <author>Marius Bogoevici</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [AttributeUsage(AttributeTargets.Class)]
     public class MessageEndpointAttribute : Attribute {
         private string _value = String.Empty;

--- a/src/Spring/Spring.Integration/Attributes/RouterAttribute.cs
+++ b/src/Spring/Spring.Integration/Attributes/RouterAttribute.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -39,7 +39,7 @@ namespace Spring.Integration.Attributes {
     /// to resolve each channel name with the Channel Registry.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [AttributeUsage(AttributeTargets.Method)]
     public class RouterAttribute : Attribute {
         private string _inputChannel = String.Empty;

--- a/src/Spring/Spring.Integration/Attributes/ServiceActivator.cs
+++ b/src/Spring/Spring.Integration/Attributes/ServiceActivator.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,7 +36,7 @@ namespace Spring.Integration.Attributes {
     /// as its payload.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [AttributeUsage(AttributeTargets.Method)]
     public class ServiceActivatorAttribute : Attribute {
         private string _inputChannel;

--- a/src/Spring/Spring.Integration/Attributes/SplitterAttribute.cs
+++ b/src/Spring/Spring.Integration/Attributes/SplitterAttribute.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -37,7 +37,7 @@ namespace Spring.Integration.Attributes {
     /// as the payload for creating a new Message.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [AttributeUsage(AttributeTargets.Method)]
     public class SplitterAttribute : Attribute {
 

--- a/src/Spring/Spring.Integration/Attributes/TransformerAttribute.cs
+++ b/src/Spring/Spring.Integration/Attributes/TransformerAttribute.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ namespace Spring.Integration.Attributes {
     /// or message payload.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [AttributeUsage(AttributeTargets.Method)]
     public class TransformerAttribute : Attribute {
 

--- a/src/Spring/Spring.Integration/Channel/AbstractMessageChannel.cs
+++ b/src/Spring/Spring.Integration/Channel/AbstractMessageChannel.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Channel/AbstractPollableChannel.cs
+++ b/src/Spring/Spring.Integration/Channel/AbstractPollableChannel.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Channel/AbstractSubscribableChannel.cs
+++ b/src/Spring/Spring.Integration/Channel/AbstractSubscribableChannel.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Channel/ChannelPurger.cs
+++ b/src/Spring/Spring.Integration/Channel/ChannelPurger.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Channel/ChannelResolutionException.cs
+++ b/src/Spring/Spring.Integration/Channel/ChannelResolutionException.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Channel/DirectChannel.cs
+++ b/src/Spring/Spring.Integration/Channel/DirectChannel.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Channel/IChannelInterceptor.cs
+++ b/src/Spring/Spring.Integration/Channel/IChannelInterceptor.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Channel/IChannelResolver.cs
+++ b/src/Spring/Spring.Integration/Channel/IChannelResolver.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ namespace Spring.Integration.Channel {
     /// Strategy for resolving a name to a <see cref="IMessageChannel"/>
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface IChannelResolver {
 
         /// <summary>

--- a/src/Spring/Spring.Integration/Channel/IPollableChannel.cs
+++ b/src/Spring/Spring.Integration/Channel/IPollableChannel.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Channel/ISubscribableChannel.cs
+++ b/src/Spring/Spring.Integration/Channel/ISubscribableChannel.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Channel/Interceptor/ChannelInterceptorAdapter.cs
+++ b/src/Spring/Spring.Integration/Channel/Interceptor/ChannelInterceptorAdapter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Channel/Interceptor/MessageSelectingInterceptor.cs
+++ b/src/Spring/Spring.Integration/Channel/Interceptor/MessageSelectingInterceptor.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Channel/Interceptor/WireTap.cs
+++ b/src/Spring/Spring.Integration/Channel/Interceptor/WireTap.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Channel/MapBasedChannelResolver.cs
+++ b/src/Spring/Spring.Integration/Channel/MapBasedChannelResolver.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Channel {
     /// instances by matching the channel name against keys within a Map.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MapBasedChannelResolver : IChannelResolver {
 
         private volatile IDictionary<string, IMessageChannel> _channelMap = new Dictionary<string, IMessageChannel>();

--- a/src/Spring/Spring.Integration/Channel/MessageChannelTemplate.cs
+++ b/src/Spring/Spring.Integration/Channel/MessageChannelTemplate.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -45,7 +45,7 @@ namespace Spring.Integration.Channel {
     /// (e.g. 'propagationBehaviorName').
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MessageChannelTemplate : IInitializingObject {
 
         protected ILog _logger = LogManager.GetLogger(typeof (MessageChannelTemplate));

--- a/src/Spring/Spring.Integration/Channel/MessagePublishingErrorHandler.cs
+++ b/src/Spring/Spring.Integration/Channel/MessagePublishingErrorHandler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Channel/NullChannel.cs
+++ b/src/Spring/Spring.Integration/Channel/NullChannel.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Channel/ObjectFactoryChannelResolver.cs
+++ b/src/Spring/Spring.Integration/Channel/ObjectFactoryChannelResolver.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Channel/PriorityChannel.cs
+++ b/src/Spring/Spring.Integration/Channel/PriorityChannel.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Channel/PublishSubscribeChannel.cs
+++ b/src/Spring/Spring.Integration/Channel/PublishSubscribeChannel.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Channel/QueueChannel.cs
+++ b/src/Spring/Spring.Integration/Channel/QueueChannel.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Channel/RendezvousChannel.cs
+++ b/src/Spring/Spring.Integration/Channel/RendezvousChannel.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Channel/ThreadLocalChannel.cs
+++ b/src/Spring/Spring.Integration/Channel/ThreadLocalChannel.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Config/AbstractMessageHandlerFactoryObject.cs
+++ b/src/Spring/Spring.Integration/Config/AbstractMessageHandlerFactoryObject.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +30,7 @@ namespace Spring.Integration.Config {
     /// Base class for FactoryBeans that create MessageHandler instances. 
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class AbstractMessageHandlerFactoryObject : IFactoryObject {
 
         private volatile IMessageHandler _handler;

--- a/src/Spring/Spring.Integration/Config/ConsumerEndpointFactoryObject.cs
+++ b/src/Spring/Spring.Integration/Config/ConsumerEndpointFactoryObject.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +33,7 @@ using Spring.Util;
 namespace Spring.Integration.Config {
 
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class ConsumerEndpointFactoryObject : IFactoryObject, IObjectFactoryAware, IObjectNameAware, IInitializingObject, IApplicationEventListener {
 
         private readonly IMessageHandler _handler;

--- a/src/Spring/Spring.Integration/Config/RouterFactoryObject.cs
+++ b/src/Spring/Spring.Integration/Config/RouterFactoryObject.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Config {
     /// Factory bean for creating a Message Router.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class RouterFactoryObject : AbstractMessageHandlerFactoryObject {
 
         private volatile IChannelResolver _channelResolver;

--- a/src/Spring/Spring.Integration/Config/SourcePollingChannelAdapterFactoryObject.cs
+++ b/src/Spring/Spring.Integration/Config/SourcePollingChannelAdapterFactoryObject.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +33,7 @@ namespace Spring.Integration.Config {
     /// FactoryBean for creating a SourcePollingChannelAdapter instance.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class SourcePollingChannelAdapterFactoryObject : IFactoryObject, IObjectFactoryAware, IObjectNameAware, /*BeanClassLoaderAware,*/ IInitializingObject {
 
         private volatile IMessageSource _source;

--- a/src/Spring/Spring.Integration/Config/SplitterFactoryObject.cs
+++ b/src/Spring/Spring.Integration/Config/SplitterFactoryObject.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ namespace Spring.Integration.Config {
     /// Factory bean for creating a Message Splitter.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class SplitterFactoryBean : AbstractMessageHandlerFactoryObject {
 
         protected override IMessageHandler CreateHandler(object targetObject, string targetMethodName) {

--- a/src/Spring/Spring.Integration/Config/TransformerFactoryObject.cs
+++ b/src/Spring/Spring.Integration/Config/TransformerFactoryObject.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ namespace Spring.Integration.Config {
     /// Factory bean for creating a Message Transformer.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class TransformerFactoryBean : AbstractMessageHandlerFactoryObject {
 
         protected override IMessageHandler CreateHandler(object targetObject, string targetMethodName) {

--- a/src/Spring/Spring.Integration/Config/Xml/AbstractChannelAdapterParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/AbstractChannelAdapterParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Config.Xml {
     /// Base parser for Channel Adapters.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class AbstractChannelAdapterParser : AbstractObjectDefinitionParser {
 
         protected override string ResolveId(XmlElement element, AbstractObjectDefinition definition, ParserContext parserContext) {

--- a/src/Spring/Spring.Integration/Config/Xml/AbstractChannelParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/AbstractChannelParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ namespace Spring.Integration.Config.Xml {
     /// Base class for channel parsers.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class AbstractChannelParser : AbstractObjectDefinitionParser {
 
         protected override AbstractObjectDefinition ParseInternal(XmlElement element, ParserContext parserContext) {

--- a/src/Spring/Spring.Integration/Config/Xml/AbstractConsumerEndpointParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/AbstractConsumerEndpointParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Config.Xml {
     /// Base class parser for elements that create Message Endpoints.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class AbstractConsumerEndpointParser : AbstractObjectDefinitionParser {
 
         protected static string RefAttribute = "ref";

--- a/src/Spring/Spring.Integration/Config/Xml/AbstractIntegrationNamespaceParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/AbstractIntegrationNamespaceParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Config/Xml/AbstractOutboundChannelAdapterParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/AbstractOutboundChannelAdapterParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Config.Xml {
     /// Base class for outbound Channel Adapter parsers.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class AbstractOutboundChannelAdapterParser : AbstractChannelAdapterParser {
 
         protected override AbstractObjectDefinition DoParse(XmlElement element, ParserContext parserContext, string channelName) {

--- a/src/Spring/Spring.Integration/Config/Xml/AbstractPollingInboundChannelAdapterParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/AbstractPollingInboundChannelAdapterParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Config.Xml {
     /// Base parser for inbound Channel Adapters that poll a source.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class AbstractPollingInboundChannelAdapterParser : AbstractChannelAdapterParser {
 
         protected override AbstractObjectDefinition DoParse(XmlElement element, ParserContext parserContext, string channelName) {

--- a/src/Spring/Spring.Integration/Config/Xml/AbstractTransformerParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/AbstractTransformerParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,7 +24,7 @@ using Spring.Objects.Factory.Xml;
 
 namespace Spring.Integration.Config.Xml {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class AbstractTransformerParser : AbstractConsumerEndpointParser {
 
         protected override ObjectDefinitionBuilder ParseHandler(XmlElement element, ParserContext parserContext) {

--- a/src/Spring/Spring.Integration/Config/Xml/AggregatorParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/AggregatorParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +30,7 @@ namespace Spring.Integration.Config.Xml {
     /// </summary>
     /// <author>Marius Bogoevici</author>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class AggregatorParser : AbstractConsumerEndpointParser {
 
         private const string CompletionStrategyRefAttribute = "completion-strategy";

--- a/src/Spring/Spring.Integration/Config/Xml/AnnotationConfigParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/AnnotationConfigParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Config.Xml {
     /// to the application context.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class AnnotationConfigParser : AbstractSingleObjectDefinitionParser {
 
         protected override string GetObjectTypeName(XmlElement element) {

--- a/src/Spring/Spring.Integration/Config/Xml/ApplicationEventMulticasterParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/ApplicationEventMulticasterParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,7 +34,7 @@ namespace Spring.Integration.Config.Xml {
     /// integration namespace.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class ApplicationEventMulticasterParser : AbstractSingleObjectDefinitionParser {
 
         protected override String GetObjectTypeName(XmlElement element) {

--- a/src/Spring/Spring.Integration/Config/Xml/BridgeParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/BridgeParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the &lt;bridge&gt; element.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class BridgeParser : AbstractConsumerEndpointParser {
 
         protected override ObjectDefinitionBuilder ParseHandler(XmlElement element, ParserContext parserContext) {

--- a/src/Spring/Spring.Integration/Config/Xml/ChainParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/ChainParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the &lt;chain&gt; element.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class ChainParser : AbstractConsumerEndpointParser {
 
         protected override ObjectDefinitionBuilder ParseHandler(XmlElement element, ParserContext parserContext) {

--- a/src/Spring/Spring.Integration/Config/Xml/ChannelInterceptorParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/ChannelInterceptorParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Config/Xml/DefaultConfiguringObjectFactoryPostProcessor.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/DefaultConfiguringObjectFactoryPostProcessor.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +33,7 @@ namespace Spring.Integration.Config.Xml {
     /// already been explicitly defined within the registry.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class DefaultConfiguringObjectFactoryPostProcessor : IObjectFactoryPostProcessor {
 
         private readonly ILog logger = LogManager.GetLogger(typeof(DefaultConfiguringObjectFactoryPostProcessor));

--- a/src/Spring/Spring.Integration/Config/Xml/FilterParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/FilterParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the &lt;filter/&gt; element.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class FilterParser : AbstractConsumerEndpointParser {
 
         protected override ObjectDefinitionBuilder ParseHandler(XmlElement element, ParserContext parserContext) {

--- a/src/Spring/Spring.Integration/Config/Xml/GatewayParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/GatewayParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the &lt;gateway/&gt; element.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class GatewayParser : AbstractSimpleObjectDefinitionParser {
 
         private static readonly string[] _referenceAttributes = new[] { "default-request-channel", "default-reply-channel", "message-mapper" };

--- a/src/Spring/Spring.Integration/Config/Xml/IObjectDefinitionRegisteringParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/IObjectDefinitionRegisteringParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ namespace Spring.Integration.Config.Xml {
     /// registering the bean. The <see cref="Parse"/> method should return the name of the registered bean.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface IObjectDefinitionRegisteringParser {
 
         /// <summary>

--- a/src/Spring/Spring.Integration/Config/Xml/IntegrationNamespaceParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/IntegrationNamespaceParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ namespace Spring.Integration.Config.Xml
     /// </summary>
     /// <author>Mark Fisher</author>
     /// <author>Marius Bogoevici</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [
         NamespaceParser(
             Namespace = "http://www.springframework.net/integration",

--- a/src/Spring/Spring.Integration/Config/Xml/IntegrationNamespaceUtils.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/IntegrationNamespaceUtils.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ namespace Spring.Integration.Config.Xml {
     /// </summary>
     /// <author>Mark Fisher</author>
     /// <author>Marius Bogoevici</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class IntegrationNamespaceUtils {
 
         public const string BASE_PACKAGE = "Spring.Integration";

--- a/src/Spring/Spring.Integration/Config/Xml/LoggingChannelAdapterParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/LoggingChannelAdapterParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the 'logging-channel-adapter' element.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class LoggingChannelAdapterParser : AbstractOutboundChannelAdapterParser {
 
         protected override AbstractObjectDefinition ParseConsumer(XmlElement element, ParserContext parserContext) {

--- a/src/Spring/Spring.Integration/Config/Xml/MethodInvokingInboundChannelAdapterParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/MethodInvokingInboundChannelAdapterParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the &lt;inbound-channel-adapter/&gt; element.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MethodInvokingInboundChannelAdapterParser : AbstractPollingInboundChannelAdapterParser {
 
         protected override string ParseSource(XmlElement element, ParserContext parserContext) {

--- a/src/Spring/Spring.Integration/Config/Xml/MethodInvokingOutboundChannelAdapterParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/MethodInvokingOutboundChannelAdapterParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the &lt;outbound-channel-adapter/&gt; element.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MethodInvokingOutboundChannelAdapterParser : AbstractOutboundChannelAdapterParser {
 
         protected override string ParseAndRegisterConsumer(XmlElement element, ParserContext parserContext) {

--- a/src/Spring/Spring.Integration/Config/Xml/ObjectToStringTransformerParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/ObjectToStringTransformerParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the 'object-to-string-transformer' element.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class ObjectToStringTransformerParser : AbstractTransformerParser {
 
         protected override string TransformerClassName {

--- a/src/Spring/Spring.Integration/Config/Xml/PayloadDeserializingTransformerParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/PayloadDeserializingTransformerParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the 'payload-serializing-transformer' element.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class PayloadDeserializingTransformerParser : AbstractTransformerParser {
 
         protected override string TransformerClassName {

--- a/src/Spring/Spring.Integration/Config/Xml/PayloadSerializingTransformerParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/PayloadSerializingTransformerParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the 'payload-serializing-transformer' element.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class PayloadSerializingTransformerParser : AbstractTransformerParser {
 
         protected override string TransformerClassName {

--- a/src/Spring/Spring.Integration/Config/Xml/PointToPointChannelParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/PointToPointChannelParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +30,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the &lt;channel&gt; element.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class PointToPointChannelParser : AbstractChannelParser {
 
         protected override ObjectDefinitionBuilder BuildObjectDefinition(XmlElement element, ParserContext parserContext) {

--- a/src/Spring/Spring.Integration/Config/Xml/PollerParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/PollerParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -38,7 +38,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the &lt;poller&gt; element.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class PollerParser : AbstractObjectDefinitionParser {
 
         protected override string ResolveId(XmlElement element, AbstractObjectDefinition definition, ParserContext parserContext) {

--- a/src/Spring/Spring.Integration/Config/Xml/PublishSubscribeChannelParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/PublishSubscribeChannelParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the &lt;publish-subscribe-channel&gt; element.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class PublishSubscribeChannelParser : AbstractChannelParser {
 
         protected override ObjectDefinitionBuilder BuildObjectDefinition(XmlElement element, ParserContext parserContext) {

--- a/src/Spring/Spring.Integration/Config/Xml/ResequencerParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/ResequencerParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the &lt;resequencer&gt; element.
     /// </summary>
     /// <author>Marius Bogoevici</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class ResequencerParser : AbstractConsumerEndpointParser {
 
         protected override ObjectDefinitionBuilder ParseHandler(XmlElement element, ParserContext parserContext) {

--- a/src/Spring/Spring.Integration/Config/Xml/RouterParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/RouterParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the &lt;router/&gt; element.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class RouterParser : AbstractConsumerEndpointParser {
 
         protected override ObjectDefinitionBuilder ParseHandler(XmlElement element, ParserContext parserContext) {

--- a/src/Spring/Spring.Integration/Config/Xml/SelectorChainParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/SelectorChainParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +30,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the &lt;selector-chain/&gt; element.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class SelectorChainParser : AbstractSingleObjectDefinitionParser {
 
         protected override string GetObjectTypeName(XmlElement element) {

--- a/src/Spring/Spring.Integration/Config/Xml/ServiceActivatorParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/ServiceActivatorParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the &lt;service-activator&gt; element.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class ServiceActivatorParser : AbstractConsumerEndpointParser {
 
         protected override ObjectDefinitionBuilder ParseHandler(XmlElement element, ParserContext parserContext) {

--- a/src/Spring/Spring.Integration/Config/Xml/SimpleHeaderEnricherParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/SimpleHeaderEnricherParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ using Spring.Objects.Factory.Xml;
 
 namespace Spring.Integration.Config.Xml {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
 public class SimpleHeaderEnricherParser : AbstractTransformerParser {
 
 	private readonly static string[] ineligibleHeaderNames = new [] {"id", "input-channel", "output-channel", "overwrite"};

--- a/src/Spring/Spring.Integration/Config/Xml/SplitterParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/SplitterParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the &lt;splitter/&gt; element.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class SplitterParser : AbstractConsumerEndpointParser {
 
         protected override ObjectDefinitionBuilder ParseHandler(XmlElement element, ParserContext parserContext) {

--- a/src/Spring/Spring.Integration/Config/Xml/StandardHeaderEnricherParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/StandardHeaderEnricherParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,7 +34,7 @@ namespace Spring.Integration.Config.Xml {
     /// references) if provided as 'header' sub-elements.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class StandardHeaderEnricherParser : SimpleHeaderEnricherParser {
 
         private static readonly string[] REFERENCE_ATTRIBUTES = new[] { "reply-channel", "error-channel" };

--- a/src/Spring/Spring.Integration/Config/Xml/ThreadLocalChannelParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/ThreadLocalChannelParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the &lt;thread-local-channel&gt; element.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class ThreadLocalChannelParser : AbstractChannelParser {
 
         protected override ObjectDefinitionBuilder BuildObjectDefinition(XmlElement element, ParserContext parserContext) {

--- a/src/Spring/Spring.Integration/Config/Xml/ThreadPoolTaskExecutorParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/ThreadPoolTaskExecutorParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the 'thread-pool-task-executor' element.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     /// <author>Anindya Chatterjee (.NET)</author>
     public class ThreadPoolTaskExecutorParser : AbstractSimpleObjectDefinitionParser {
 

--- a/src/Spring/Spring.Integration/Config/Xml/TransformerParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/TransformerParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the &lt;transformer/&gt; element.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class TransformerParser : AbstractConsumerEndpointParser {
 
         protected override ObjectDefinitionBuilder ParseHandler(XmlElement element, ParserContext parserContext) {

--- a/src/Spring/Spring.Integration/Config/Xml/WireTapParser.cs
+++ b/src/Spring/Spring.Integration/Config/Xml/WireTapParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Config.Xml {
     /// Parser for the &lt;wire-tap&gt; element.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class WireTapParser : IObjectDefinitionRegisteringParser {
 
         public string Parse(XmlElement element, ParserContext parserContext) {

--- a/src/Spring/Spring.Integration/Context/IntegrationContextUtils.cs
+++ b/src/Spring/Spring.Integration/Context/IntegrationContextUtils.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -35,7 +35,7 @@ namespace Spring.Integration.Context {
     /// 
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     /// <author>Anindya Chatterjee (.NET)</author>
     public abstract class IntegrationContextUtils {
         public const string TaskSchedulerObjectName = "taskScheduler";

--- a/src/Spring/Spring.Integration/Context/IntegrationObjectSupport.cs
+++ b/src/Spring/Spring.Integration/Context/IntegrationObjectSupport.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -35,7 +35,7 @@ namespace Spring.Integration.Context {
     /// dependency injection.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class IntegrationObjectSupport : IObjectNameAware, IObjectFactoryAware {
 
         /** Logger that is available to subclasses */

--- a/src/Spring/Spring.Integration/Core/Generic/IMessage.cs
+++ b/src/Spring/Spring.Integration/Core/Generic/IMessage.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,7 +24,7 @@ namespace Spring.Integration.Core.Generic {
     /// </summary>
     /// <author>Mark Fisher</author>
     /// <author>Arjen Poutsma</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface IMessage<T> : IMessage {
         /// <summary>
         /// get the payload, that is the body, of the message

--- a/src/Spring/Spring.Integration/Core/IMessage.cs
+++ b/src/Spring/Spring.Integration/Core/IMessage.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,7 @@ namespace Spring.Integration.Core {
     /// </summary>
     /// <author>Mark Fisher</author>
     /// <author>Arjen Poutsma</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface IMessage {
 
         /// <summary>

--- a/src/Spring/Spring.Integration/Core/IMessageChannel.cs
+++ b/src/Spring/Spring.Integration/Core/IMessageChannel.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ namespace Spring.Integration.Core {
     /// Base channel interface defining common behavior for message sending and receiving.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface IMessageChannel {
         /// <summary>
         /// Gets the name of this channel.

--- a/src/Spring/Spring.Integration/Core/MessageHeaders.cs
+++ b/src/Spring/Spring.Integration/Core/MessageHeaders.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Core {
     /// </summary>
     /// <author>Arjen Poutsma</author>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [Serializable]
     public sealed class MessageHeaders : IDictionary<string, object> { 
 

--- a/src/Spring/Spring.Integration/Core/MessagePriority.cs
+++ b/src/Spring/Spring.Integration/Core/MessagePriority.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,7 +24,7 @@ namespace Spring.Integration.Core {
     /// An enumeration of the possible values for a message's priority. 
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     /// <see cref="MessageHeaders.Priority"/>
     public enum MessagePriority {
         /// <summary>

--- a/src/Spring/Spring.Integration/Core/MessagingException.cs
+++ b/src/Spring/Spring.Integration/Core/MessagingException.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,7 @@ namespace Spring.Integration.Core {
     /// The base generic exception for any failures within the messaging system.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MessagingException : ApplicationException {
 
         private readonly IMessage _failedMessage;

--- a/src/Spring/Spring.Integration/Dispatcher/AbstractDispatcher.cs
+++ b/src/Spring/Spring.Integration/Dispatcher/AbstractDispatcher.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Dispatcher/BroadcastingDispatcher.cs
+++ b/src/Spring/Spring.Integration/Dispatcher/BroadcastingDispatcher.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Dispatcher/IMessageDispatcher.cs
+++ b/src/Spring/Spring.Integration/Dispatcher/IMessageDispatcher.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Dispatcher/SimpleDispatcher.cs
+++ b/src/Spring/Spring.Integration/Dispatcher/SimpleDispatcher.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Endpoint/AbstractEndpoint.cs
+++ b/src/Spring/Spring.Integration/Endpoint/AbstractEndpoint.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Endpoint/AbstractPollingEndpoint.cs
+++ b/src/Spring/Spring.Integration/Endpoint/AbstractPollingEndpoint.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Endpoint/EventDrivenConsumer.cs
+++ b/src/Spring/Spring.Integration/Endpoint/EventDrivenConsumer.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Endpoint/MessageProducerSupport.cs
+++ b/src/Spring/Spring.Integration/Endpoint/MessageProducerSupport.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Endpoint/PollingConsumer.cs
+++ b/src/Spring/Spring.Integration/Endpoint/PollingConsumer.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Endpoint/SourcePollingChannelAdapter.cs
+++ b/src/Spring/Spring.Integration/Endpoint/SourcePollingChannelAdapter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Event/ApplicationEventInboundChannelAdapter.cs
+++ b/src/Spring/Spring.Integration/Event/ApplicationEventInboundChannelAdapter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ namespace Spring.Integration.Event {
     /// {@link ApplicationEvent ApplicationEvents} within messages.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class ApplicationEventInboundChannelAdapter : MessageProducerSupport, IApplicationEventListener {
 
         private readonly IList<Type> _eventTypes = new CopyOnWriteArrayList<Type>();

--- a/src/Spring/Spring.Integration/Event/ApplicationEventPublishingMessageHandler.cs
+++ b/src/Spring/Spring.Integration/Event/ApplicationEventPublishingMessageHandler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ namespace Spring.Integration.Event {
     /// {@link Message}.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class ApplicationEventPublishingMessageHandler<T> : AbstractMessageHandler, IApplicationContextAware {
 
         private IApplicationEventPublisher applicationEventPublisher;

--- a/src/Spring/Spring.Integration/Event/MessagingEvent.cs
+++ b/src/Spring/Spring.Integration/Event/MessagingEvent.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ namespace Spring.Integration.Event {
     /// A subclass of {@link ApplicationEvent} that wraps a {@link Message}.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MessagingEventArgs : ApplicationEventArgs {
         private IMessage _message;
 

--- a/src/Spring/Spring.Integration/Filter/MessageFilter.cs
+++ b/src/Spring/Spring.Integration/Filter/MessageFilter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,7 +34,7 @@ namespace Spring.Integration.Filter {
     /// {@link #throwExceptionOnRejection} property.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MessageFilter : AbstractReplyProducingMessageHandler {
 
         private readonly IMessageSelector _selector;

--- a/src/Spring/Spring.Integration/Filter/MethodInvokingSelector.cs
+++ b/src/Spring/Spring.Integration/Filter/MethodInvokingSelector.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +30,7 @@ namespace Spring.Integration.Filter {
     /// A method-invoking implementation of {@link MessageSelector}.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MethodInvokingSelector : IMessageSelector {
 
         private MessageMappingMethodInvoker _invoker;

--- a/src/Spring/Spring.Integration/Gateway/AbstractMessagingGateway.cs
+++ b/src/Spring/Spring.Integration/Gateway/AbstractMessagingGateway.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Gateway/GatewayProxyFactoryObject.cs
+++ b/src/Spring/Spring.Integration/Gateway/GatewayProxyFactoryObject.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Gateway/IMessagingGateway.cs
+++ b/src/Spring/Spring.Integration/Gateway/IMessagingGateway.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Gateway/SimpleMessageMapper.cs
+++ b/src/Spring/Spring.Integration/Gateway/SimpleMessageMapper.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Gateway/SimpleMessagingGateway.cs
+++ b/src/Spring/Spring.Integration/Gateway/SimpleMessagingGateway.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Handler/AbstractMessageHandler.cs
+++ b/src/Spring/Spring.Integration/Handler/AbstractMessageHandler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +33,7 @@ namespace Spring.Integration.Handler {
     /// checked exceptions into runtime {@link MessagingException}s. 
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class AbstractMessageHandler : IMessageHandler, IOrdered {
 
         protected ILog logger = LogManager.GetLogger(typeof(AbstractMessageHandler));

--- a/src/Spring/Spring.Integration/Handler/AbstractReplyProducingMessageHandler.cs
+++ b/src/Spring/Spring.Integration/Handler/AbstractReplyProducingMessageHandler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ namespace Spring.Integration.Handler {
     /// Base class for MessageHandlers that are capable of producing replies.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class AbstractReplyProducingMessageHandler : AbstractMessageHandler, IObjectFactoryAware {
 
         public static TimeSpan DEFAULT_SEND_TIMEOUT = TimeSpan.FromMilliseconds(1000);

--- a/src/Spring/Spring.Integration/Handler/BridgeHandler.cs
+++ b/src/Spring/Spring.Integration/Handler/BridgeHandler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ namespace Spring.Integration.Handler {
     /// vice-versa.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class BridgeHandler : AbstractReplyProducingMessageHandler {
 
         protected override void HandleRequestMessage(IMessage requestMessage, ReplyMessageHolder replyMessageHolder) {

--- a/src/Spring/Spring.Integration/Handler/HandlerMethodUtils.cs
+++ b/src/Spring/Spring.Integration/Handler/HandlerMethodUtils.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Handler {
     /// Utility methods for common behavior related to Message-handling methods.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class HandlerMethodUtils {
 
         /// <summary>

--- a/src/Spring/Spring.Integration/Handler/IHandlerMethodResolver.cs
+++ b/src/Spring/Spring.Integration/Handler/IHandlerMethodResolver.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ namespace Spring.Integration.Handler {
     /// handling a given {@link Message}.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface IHandlerMethodResolver {
 
         /// <summary>

--- a/src/Spring/Spring.Integration/Handler/LoggingHandler.cs
+++ b/src/Spring/Spring.Integration/Handler/LoggingHandler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ namespace Spring.Integration.Handler {
     /// is assignable to Throwable, it will log the stack trace.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class LoggingHandler : AbstractMessageHandler {
 
         private enum Level { FATAL, ERROR, WARN, INFO, DEBUG, TRACE };

--- a/src/Spring/Spring.Integration/Handler/MessageHandlerChain.cs
+++ b/src/Spring/Spring.Integration/Handler/MessageHandlerChain.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -35,7 +35,7 @@ namespace Spring.Integration.Handler {
     /// MessageHandler instances in order.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MessageHandlerChain : IntegrationObjectSupport, IMessageHandler {
 
         private volatile IList<IMessageHandler> _handlers;

--- a/src/Spring/Spring.Integration/Handler/MessageMappingMethodInvoker.cs
+++ b/src/Spring/Spring.Integration/Handler/MessageMappingMethodInvoker.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,7 +36,7 @@ namespace Spring.Integration.Handler {
     /// 'methodName', or an Annotation type must be provided.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MessageMappingMethodInvoker {
 
         protected static ILog logger = LogManager.GetLogger(typeof(MessageMappingMethodInvoker));

--- a/src/Spring/Spring.Integration/Handler/MethodInvokingMessageHandler.cs
+++ b/src/Spring/Spring.Integration/Handler/MethodInvokingMessageHandler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ namespace Spring.Integration.Handler {
     /// A {@link MessageHandler} that invokes the specified method on the provided object.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MethodInvokingMessageHandler : MessageMappingMethodInvoker, IMessageHandler {
 
         public MethodInvokingMessageHandler(object obj, MethodInfo method)

--- a/src/Spring/Spring.Integration/Handler/PayloadTypeMatchingHandlerMethodResolver.cs
+++ b/src/Spring/Spring.Integration/Handler/PayloadTypeMatchingHandlerMethodResolver.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ namespace Spring.Integration.Handler {
     /// type of the Message against the expected type of its candidate methods.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class PayloadTypeMatchingHandlerMethodResolver : IHandlerMethodResolver {
 
         private readonly IDictionary<Type, MethodInfo> _methodMap = new Dictionary<Type, MethodInfo>();

--- a/src/Spring/Spring.Integration/Handler/ReplyMessageHolder.cs
+++ b/src/Spring/Spring.Integration/Handler/ReplyMessageHolder.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,7 @@ using Spring.Integration.Message;
 
 namespace Spring.Integration.Handler {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class ReplyMessageHolder {
 
         private readonly IList<MessageBuilder> builders = new List<MessageBuilder>();

--- a/src/Spring/Spring.Integration/Handler/ServiceActivatingHandler.cs
+++ b/src/Spring/Spring.Integration/Handler/ServiceActivatingHandler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ namespace Spring.Integration.Handler {
     /// <summary>
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class ServiceActivatingHandler : AbstractReplyProducingMessageHandler {
 
         private MessageMappingMethodInvoker invoker;

--- a/src/Spring/Spring.Integration/Handler/StaticHandlerMethodResolver.cs
+++ b/src/Spring/Spring.Integration/Handler/StaticHandlerMethodResolver.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Handler {
     /// or otherwise resolvable in advance based on static metadata.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class StaticHandlerMethodResolver : IHandlerMethodResolver {
 
         private readonly MethodInfo _method;

--- a/src/Spring/Spring.Integration/Message/ErrorMessage.cs
+++ b/src/Spring/Spring.Integration/Message/ErrorMessage.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ namespace Spring.Integration.Message {
     /// A message implementation that accepts an <see cref="Exception"/> payload. 
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class ErrorMessage : Message<Exception> {
 
         /// <summary>

--- a/src/Spring/Spring.Integration/Message/Generic/IInboundMessageMapper.cs
+++ b/src/Spring/Spring.Integration/Message/Generic/IInboundMessageMapper.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,7 @@ namespace Spring.Integration.Message.Generic {
     /// Strategy interface for mapping from an Object to a <see cref="IMessage{T}"/>.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface IInboundMessageMapper<T> : IInboundMessageMapper {
 
         /// <summary>

--- a/src/Spring/Spring.Integration/Message/Generic/IOutboundMessageMapper.cs
+++ b/src/Spring/Spring.Integration/Message/Generic/IOutboundMessageMapper.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,7 @@ namespace Spring.Integration.Message.Generic {
     /// Strategy interface for mapping from a <see cref="IMessage{T}"/> to an <see cref="object"/>.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface IOutboundMessageMapper<T> : IOutboundMessageMapper {
 
         /// <summary>

--- a/src/Spring/Spring.Integration/Message/Generic/Message.cs
+++ b/src/Spring/Spring.Integration/Message/Generic/Message.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ namespace Spring.Integration.Message.Generic {
     /// Base Message class defining common properties such as id, payload, and headers.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [Serializable]
     public class Message<T> : Message, IMessage<T> {
 

--- a/src/Spring/Spring.Integration/Message/IInboundMessageMapper.cs
+++ b/src/Spring/Spring.Integration/Message/IInboundMessageMapper.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,7 @@ namespace Spring.Integration.Message {
     /// Strategy interface for mapping from an Object to a <see cref="IMessage"/>.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface IInboundMessageMapper {
 
         /// <summary>

--- a/src/Spring/Spring.Integration/Message/IMessageHandler.cs
+++ b/src/Spring/Spring.Integration/Message/IMessageHandler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,7 @@ namespace Spring.Integration.Message {
     /// Base interface for any component that handles Messages.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface IMessageHandler {
 
         /// <summary>

--- a/src/Spring/Spring.Integration/Message/IMessageSource.cs
+++ b/src/Spring/Spring.Integration/Message/IMessageSource.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,7 @@ namespace Spring.Integration.Message {
     /// Base interface for any source of <see cref="IMessage"/> that can be polled. 
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface IMessageSource {
         /// <summary>
         /// Retrieve the next available message from this source.

--- a/src/Spring/Spring.Integration/Message/IOutboundMessageMapper.cs
+++ b/src/Spring/Spring.Integration/Message/IOutboundMessageMapper.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,7 @@ namespace Spring.Integration.Message {
     /// Strategy interface for mapping from a <see cref="IMessage"/> to an <see cref="object"/>.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface IOutboundMessageMapper {
 
         /// <summary>

--- a/src/Spring/Spring.Integration/Message/Message.cs
+++ b/src/Spring/Spring.Integration/Message/Message.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Message {
     /// Base Message class defining common properties such as id, payload, and headers.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [Serializable]
     public class Message : IMessage { 
 

--- a/src/Spring/Spring.Integration/Message/MessageBuilder.cs
+++ b/src/Spring/Spring.Integration/Message/MessageBuilder.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +30,7 @@ namespace Spring.Integration.Message {
     /// </summary>
     /// <author>Arjen Poutsma</author>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public sealed class MessageBuilder {
 
         private readonly object _payload;

--- a/src/Spring/Spring.Integration/Message/MessageDeliveryException.cs
+++ b/src/Spring/Spring.Integration/Message/MessageDeliveryException.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ namespace Spring.Integration.Message {
     /// Exception that indicates an error during message delivery.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MessageDeliveryException : MessagingException {
 
         /// <summary>

--- a/src/Spring/Spring.Integration/Message/MessageHandlingException.cs
+++ b/src/Spring/Spring.Integration/Message/MessageHandlingException.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ namespace Spring.Integration.Message {
     /// Exception that indicates an error during message handling.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MessageHandlingException : MessagingException {
 
         /// <summary>

--- a/src/Spring/Spring.Integration/Message/MessageRejectedException.cs
+++ b/src/Spring/Spring.Integration/Message/MessageRejectedException.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ namespace Spring.Integration.Message {
     /// Exception that indicates a message has been rejected by a selector.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MessageRejectedException : MessageHandlingException {
 
         /// <summary>

--- a/src/Spring/Spring.Integration/Message/MessageTimeoutException.cs
+++ b/src/Spring/Spring.Integration/Message/MessageTimeoutException.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ namespace Spring.Integration.Message {
     /// Strategy interface for mapping from a <see cref="IMessage"/> to an <see cref="object"/>.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MessageTimeoutException : MessageHandlingException {
 
         /// <summary>

--- a/src/Spring/Spring.Integration/Message/MethodInvokingMessageSource.cs
+++ b/src/Spring/Spring.Integration/Message/MethodInvokingMessageSource.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ namespace Spring.Integration.Message {
     /// that its return value may be sent to a channel.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MethodInvokingMessageSource : IMessageSource, IInitializingObject {
 
         private volatile object obj;

--- a/src/Spring/Spring.Integration/Message/MethodParameterMessageMapper.cs
+++ b/src/Spring/Spring.Integration/Message/MethodParameterMessageMapper.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -43,7 +43,7 @@ namespace Spring.Integration.Message {
     /// case of a Properties-typed parameter.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MethodParameterMessageMapper : IInboundMessageMapper, IOutboundMessageMapper {
 
         private static ILog logger = LogManager.GetLogger(typeof (MethodParameterMessageMapper));

--- a/src/Spring/Spring.Integration/Message/StringMessage.cs
+++ b/src/Spring/Spring.Integration/Message/StringMessage.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ namespace Spring.Integration.Message {
     /// A message implementation that accepts a <see cref="string"/> payload. 
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TypeConverter(typeof(StringMessageTypeConverter))]
     public class StringMessage : Message<string> {
 

--- a/src/Spring/Spring.Integration/Router/AbstractChannelNameResolvingMessageRouter.cs
+++ b/src/Spring/Spring.Integration/Router/AbstractChannelNameResolvingMessageRouter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ namespace Spring.Integration.Router {
     /// the channel name(s) rather than {@link MessageChannel} instances.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class AbstractChannelNameResolvingMessageRouter : AbstractMessageRouter, IObjectFactoryAware, IInitializingObject {
 
         private volatile IChannelResolver _channelResolver;

--- a/src/Spring/Spring.Integration/Router/AbstractMessageRouter.cs
+++ b/src/Spring/Spring.Integration/Router/AbstractMessageRouter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +30,7 @@ namespace Spring.Integration.Router {
     /// Base class for Message Routers.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class AbstractMessageRouter : AbstractMessageHandler {
 
         private volatile IMessageChannel _defaultOutputChannel;

--- a/src/Spring/Spring.Integration/Router/AbstractSingleChannelNameRouter.cs
+++ b/src/Spring/Spring.Integration/Router/AbstractSingleChannelNameRouter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ namespace Spring.Integration.Router {
     /// the channel name(s) rather than {@link MessageChannel} instances.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class AbstractSingleChannelNameRouter : AbstractChannelNameResolvingMessageRouter {
 
         protected override string[] DetermineTargetChannelNames(IMessage message) {

--- a/src/Spring/Spring.Integration/Router/AbstractSingleChannelRouter.cs
+++ b/src/Spring/Spring.Integration/Router/AbstractSingleChannelRouter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ namespace Spring.Integration.Router {
     /// always return a single {@link MessageChannel} instance (or null).
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class AbstractSingleChannelRouter : AbstractMessageRouter {
 
         protected override ICollection<IMessageChannel> DetermineTargetChannels(IMessage message) {

--- a/src/Spring/Spring.Integration/Router/ErrorMessageExceptionTypeRouter.cs
+++ b/src/Spring/Spring.Integration/Router/ErrorMessageExceptionTypeRouter.cs
@@ -7,7 +7,7 @@
 // * you may not use this file except in compliance with the License.
 // * You may obtain a copy of the License at
 // *
-// *      http://www.apache.org/licenses/LICENSE-2.0
+// *      https://www.apache.org/licenses/LICENSE-2.0
 // *
 // * Unless required by applicable law or agreed to in writing, software
 // * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@
 //    /// the most specific cause of the error for which a channel-mapping exists.
 //    /// </summary>
 //    /// <author>Mark Fisher</author>
-//    /// <author>Andreas Döhring (.NET)</author>
+//    /// <author>Andreas Dï¿½hring (.NET)</author>
 //public class ErrorMessageExceptionTypeRouter : AbstractSingleChannelRouter {
 
 //    private volatile Map<Class<? extends Throwable>, MessageChannel> exceptionTypeChannelMap =

--- a/src/Spring/Spring.Integration/Router/MethodInvokingRouter.cs
+++ b/src/Spring/Spring.Integration/Router/MethodInvokingRouter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -37,7 +37,7 @@ namespace Spring.Integration.Router {
     /// {@link ChannelResolver} is required.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MethodInvokingRouter : AbstractMessageRouter {
 
         private readonly MessageMappingMethodInvoker _invoker;

--- a/src/Spring/Spring.Integration/Router/PayloadTypeRouter.cs
+++ b/src/Spring/Spring.Integration/Router/PayloadTypeRouter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +30,7 @@ namespace Spring.Integration.Router {
     /// {@link Message Message's} payload type.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class PayloadTypeRouter : AbstractSingleChannelRouter {
 
         private volatile IDictionary<Type, IMessageChannel> _payloadTypeChannelMap = new Dictionary<Type, IMessageChannel>();//TODO  new ConcurrentHashMap<Class<?>, MessageChannel>();

--- a/src/Spring/Spring.Integration/Router/RecipientListRouter.cs
+++ b/src/Spring/Spring.Integration/Router/RecipientListRouter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ namespace Spring.Integration.Router {
     /// annotation or extending {@link AbstractChannelNameResolvingMessageRouter}. 
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class RecipientListRouter : AbstractMessageRouter, IInitializingObject {
 
         private volatile IList<IMessageChannel> _channels;

--- a/src/Spring/Spring.Integration/Scheduling/CronTrigger.cs
+++ b/src/Spring/Spring.Integration/Scheduling/CronTrigger.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ namespace Spring.Integration.Scheduling {
     /// for a detailed description of the expression pattern syntax.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     /// <author>Anindya Chatterjee (.NET)</author>
     public class CronTrigger : ITrigger {
 

--- a/src/Spring/Spring.Integration/Scheduling/ITaskScheduler.cs
+++ b/src/Spring/Spring.Integration/Scheduling/ITaskScheduler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Scheduling {
     /// <author>Mark Fisher</author>
     /// <author>Marius Bogoevici</author>
     /// <author>Iwein Fuld</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface ITaskScheduler : ILifecycle {
         /// <summary>
         /// Schedules a task for multiple executions according to a Trigger.

--- a/src/Spring/Spring.Integration/Scheduling/ITrigger.cs
+++ b/src/Spring/Spring.Integration/Scheduling/ITrigger.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,7 @@ namespace Spring.Integration.Scheduling {
     /// A strategy for providing the next time a task should run.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface ITrigger {
         /// <summary>
         /// Returns the next time that a task should run or <c>null</c> if the task should not run again.

--- a/src/Spring/Spring.Integration/Scheduling/IntervalTrigger.cs
+++ b/src/Spring/Spring.Integration/Scheduling/IntervalTrigger.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +30,7 @@ namespace Spring.Integration.Scheduling {
     /// execution, set 'fixedRate' to true.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class IntervalTrigger : ITrigger {
 
         private readonly TimeSpan interval;

--- a/src/Spring/Spring.Integration/Scheduling/PollerMetadata.cs
+++ b/src/Spring/Spring.Integration/Scheduling/PollerMetadata.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ using Spring.Transaction;
 
 namespace Spring.Integration.Scheduling {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class PollerMetadata {
 
         private volatile ITrigger trigger;

--- a/src/Spring/Spring.Integration/Scheduling/SchedulingException.cs
+++ b/src/Spring/Spring.Integration/Scheduling/SchedulingException.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Scheduling/SimpleTaskScheduler.cs
+++ b/src/Spring/Spring.Integration/Scheduling/SimpleTaskScheduler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -46,7 +46,7 @@ namespace Spring.Integration.Scheduling {
     /// </summary>
     /// <author>Mark Fisher</author>
     /// <author>Marius Bogoevici</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class SimpleTaskScheduler : ITaskScheduler, IObjectFactoryAware, IApplicationEventListener, IDisposable { //}DisposableBean {
 
         private readonly ILog logger = LogManager.GetLogger(typeof(SimpleTaskScheduler));

--- a/src/Spring/Spring.Integration/Selector/IMessageSelector.cs
+++ b/src/Spring/Spring.Integration/Selector/IMessageSelector.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,7 @@ namespace Spring.Integration.Selector {
     /// Strategy interface for message selection.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface IMessageSelector {
 
         /// <summary>

--- a/src/Spring/Spring.Integration/Selector/MessageSelectorChain.cs
+++ b/src/Spring/Spring.Integration/Selector/MessageSelectorChain.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +33,7 @@ namespace Spring.Integration.Selector {
     /// accordance with this chain's {@link VotingStrategyKind}.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MessageSelectorChain : IMessageSelector {
 
         /// <summary>

--- a/src/Spring/Spring.Integration/Selector/PayloadTypeSelector.cs
+++ b/src/Spring/Spring.Integration/Selector/PayloadTypeSelector.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +30,7 @@ namespace Spring.Integration.Selector {
     /// of the selector's accepted types.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class PayloadTypeSelector : IMessageSelector {
 
         private readonly IList<Type> _acceptedTypes = new List<Type>();

--- a/src/Spring/Spring.Integration/Selector/UnexpiredMessageSelector.cs
+++ b/src/Spring/Spring.Integration/Selector/UnexpiredMessageSelector.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ namespace Spring.Integration.Selector {
     /// <code>null</code>, that Message <em>never</em> expires.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class UnexpiredMessageSelector : IMessageSelector {
 
         public bool Accept(IMessage message) {

--- a/src/Spring/Spring.Integration/Splitter/AbstractMessageSplitter.cs
+++ b/src/Spring/Spring.Integration/Splitter/AbstractMessageSplitter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ namespace Spring.Integration.Splitter {
     /// Base class for Message-splitting handlers.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class AbstractMessageSplitter : AbstractReplyProducingMessageHandler {
 
         protected override void HandleRequestMessage(IMessage message, ReplyMessageHolder replyHolder) {

--- a/src/Spring/Spring.Integration/Splitter/DefaultMessageSplitter.cs
+++ b/src/Spring/Spring.Integration/Splitter/DefaultMessageSplitter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ namespace Spring.Integration.Splitter {
     /// those delimiters.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class DefaultMessageSplitter : AbstractMessageSplitter {
 
         private volatile string _delimiters;

--- a/src/Spring/Spring.Integration/Splitter/MethodInvokingSplitter.cs
+++ b/src/Spring/Spring.Integration/Splitter/MethodInvokingSplitter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,7 +32,7 @@ namespace Spring.Integration.Splitter {
     /// single reply Message.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MethodInvokingSplitter : AbstractMessageSplitter {
 
         private MessageMappingMethodInvoker _invoker;

--- a/src/Spring/Spring.Integration/Transformer/AbstractHeaderTransformer.cs
+++ b/src/Spring/Spring.Integration/Transformer/AbstractHeaderTransformer.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Transformer {
     /// the header values of a {@link Message}.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class AbstractHeaderTransformer : ITransformer {
 
         public IMessage Transform(IMessage message) {

--- a/src/Spring/Spring.Integration/Transformer/AbstractPayloadTransformer.cs
+++ b/src/Spring/Spring.Integration/Transformer/AbstractPayloadTransformer.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ namespace Spring.Integration.Transformer {
     /// the payload of a {@link Message}.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class AbstractPayloadTransformer<T, U> : ITransformer {
 
         public IMessage Transform(IMessage message) {

--- a/src/Spring/Spring.Integration/Transformer/HeaderEnricher.cs
+++ b/src/Spring/Spring.Integration/Transformer/HeaderEnricher.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,7 +32,7 @@ namespace Spring.Integration.Transformer {
     /// a given key, will <em>not</em> be replaced.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class HeaderEnricher : AbstractHeaderTransformer {
 
         private readonly IDictionary<string, object> _headersToAdd;

--- a/src/Spring/Spring.Integration/Transformer/ITransformer.cs
+++ b/src/Spring/Spring.Integration/Transformer/ITransformer.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,7 @@ namespace Spring.Integration.Transformer {
     /// Strategy interface for transforming a {@link Message}.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface ITransformer {
 
         IMessage Transform(IMessage message);

--- a/src/Spring/Spring.Integration/Transformer/MessageTransformationException.cs
+++ b/src/Spring/Spring.Integration/Transformer/MessageTransformationException.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ namespace Spring.Integration.Transformer {
     /// Base Exception type for Message transformation errors.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MessageTransformationException : MessagingException {
 
         public MessageTransformationException(IMessage message, string description, Exception cause)

--- a/src/Spring/Spring.Integration/Transformer/MessageTransformingChannelInterceptor.cs
+++ b/src/Spring/Spring.Integration/Transformer/MessageTransformingChannelInterceptor.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ namespace Spring.Integration.Transformer {
     /// when either sending-to or receiving-from a channel.
     /// </summary>
     /// <author>Jonas Partner</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MessageTransformingChannelInterceptor : ChannelInterceptorAdapter {
 
         private readonly ITransformer _transformer;

--- a/src/Spring/Spring.Integration/Transformer/MessageTransformingHandler.cs
+++ b/src/Spring/Spring.Integration/Transformer/MessageTransformingHandler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +30,7 @@ namespace Spring.Integration.Transformer {
     /// and sends the result to its output channel.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MessageTransformingHandler : AbstractReplyProducingMessageHandler {
 
         private ITransformer _transformer;

--- a/src/Spring/Spring.Integration/Transformer/MethodInvokingTransformer.cs
+++ b/src/Spring/Spring.Integration/Transformer/MethodInvokingTransformer.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ using Spring.Util;
 
 namespace Spring.Integration.Transformer {
     /// <author>Jonas Partner</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class MethodInvokingTransformer : ITransformer {
 
         private MessageMappingMethodInvoker _invoker;

--- a/src/Spring/Spring.Integration/Transformer/ObjectToStringTransformer.cs
+++ b/src/Spring/Spring.Integration/Transformer/ObjectToStringTransformer.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,7 +24,7 @@ namespace Spring.Integration.Transformer {
     /// inbound payload Object's <code>toString()</code> method.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class ObjectToStringTransformer : AbstractPayloadTransformer<object, string> {
 
         protected override string TransformPayload(object payload) {

--- a/src/Spring/Spring.Integration/Transformer/PayloadDeserializingTransformer.cs
+++ b/src/Spring/Spring.Integration/Transformer/PayloadDeserializingTransformer.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Transformer {
     /// <p>The byte array payload must be a result of serialization.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class PayloadDeserializingTransformer : AbstractPayloadTransformer<byte[], object> {
 
         protected override object TransformPayload(byte[] payload) {

--- a/src/Spring/Spring.Integration/Transformer/PayloadSerializingTransformer.cs
+++ b/src/Spring/Spring.Integration/Transformer/PayloadSerializingTransformer.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Transformer {
     /// <p>The payload instance must be Serializable.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class PayloadSerializingTransformer : AbstractPayloadTransformer<object, byte[]> {
 
         protected override byte[] TransformPayload(object payload) {

--- a/src/Spring/Spring.Integration/Util/CustomizableThreadCreator.cs
+++ b/src/Spring/Spring.Integration/Util/CustomizableThreadCreator.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,7 +32,7 @@ namespace Spring.Integration.Util {
     /// {@link org.springframework.scheduling.concurrent.CustomizableThreadFactory}.
     /// </summary>
     /// <author>Juergen Hoeller</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class CustomizableThreadCreator {
 
         private string _threadNamePrefix;

--- a/src/Spring/Spring.Integration/Util/CustomizableThreadFactory.cs
+++ b/src/Spring/Spring.Integration/Util/CustomizableThreadFactory.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,7 +32,7 @@ namespace Spring.Integration.Util {
     /// for details on the available configuration options.
     /// </summary>
     /// <author>Juergen Hoeller</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class CustomizableThreadFactory : CustomizableThreadCreator, IThreadFactory {
 
         /// <summary>

--- a/src/Spring/Spring.Integration/Util/DefaultMethodInvoker.cs
+++ b/src/Spring/Spring.Integration/Util/DefaultMethodInvoker.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ namespace Spring.Integration.Util {
     /// Implementation of {@link MethodInvoker} to be used when the actual {@link Method} reference is known.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class DefaultMethodInvoker : IMethodInvoker {
 
         private readonly object _obj;

--- a/src/Spring/Spring.Integration/Util/DictionaryUtils.cs
+++ b/src/Spring/Spring.Integration/Util/DictionaryUtils.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,7 +23,7 @@ namespace Spring.Integration.Util {
     /// <summary>
     /// utility class for <see cref="Dictionary{TKey,TValue}"/>
     /// </summary>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class DictionaryUtils {
         /// <summary>
         /// Associates the specified value with the specified key in this map. If the map previously contained a mapping for this key, the old value is replaced. 

--- a/src/Spring/Spring.Integration/Util/DomUtils.cs
+++ b/src/Spring/Spring.Integration/Util/DomUtils.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Integration/Util/ErrorHandlingTaskExecutor.cs
+++ b/src/Spring/Spring.Integration/Util/ErrorHandlingTaskExecutor.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ namespace Spring.Integration.Util {
     /// </summary>
     /// <author>Jonas Partner</author>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class ErrorHandlingTaskExecutor : IExecutor {
 
         private readonly IExecutor _taskExecutor;

--- a/src/Spring/Spring.Integration/Util/IMethodInvoker.cs
+++ b/src/Spring/Spring.Integration/Util/IMethodInvoker.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,7 @@ namespace Spring.Integration.Util {
     /// Typically used by adapters.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface IMethodInvoker {
 
         /// <summary>

--- a/src/Spring/Spring.Integration/Util/IMethodValidator.cs
+++ b/src/Spring/Spring.Integration/Util/IMethodValidator.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ namespace Spring.Integration.Util {
     /// the method is invalid for its purpose.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface IMethodValidator {
 
         /// <summary>

--- a/src/Spring/Spring.Integration/Util/NameResolvingMethodInvoker.cs
+++ b/src/Spring/Spring.Integration/Util/NameResolvingMethodInvoker.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ namespace Spring.Integration.Util {
     /// Implementation of {@link MethodInvoker} to be used when only the method name is known.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class NameResolvingMethodInvoker : IMethodInvoker {
 
         private readonly object _obj;

--- a/src/Spring/Spring.Integration/Util/ThreadPoolTaskExecutor.cs
+++ b/src/Spring/Spring.Integration/Util/ThreadPoolTaskExecutor.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -50,7 +50,7 @@ namespace Spring.Integration.Util {
     /// in particular regarding the {@link org.springframework.core.task.TaskRejectedException}.
     /// </summary>
     /// <author>Juergen Hoeller</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     /// <author>Anindya Chatterjee (.NET)</author>
     public class ThreadPoolTaskExecutor : CustomizableThreadFactory, /*SchedulingTaskExecutor,*/ IExecutor, IObjectNameAware, IInitializingObject, IDisposable {
 

--- a/src/Spring/Spring.Integration/Xml/IXmlPayloadConverter.cs
+++ b/src/Spring/Spring.Integration/Xml/IXmlPayloadConverter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,7 @@ namespace Spring.Integration.Xml {
     /// Converter for creating XML <see cref="XmlDocument"/> instances
     /// </summary>
     /// <author>Jonas Partner</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface IXmlPayloadConverter {
 
         XmlDocument ConvertToDocument(object obj);

--- a/test/Spring/Spring.Integration.Nms.Tests/Nms/ChannelPublishingJmsMessageListenerTests.cs
+++ b/test/Spring/Spring.Integration.Nms.Tests/Nms/ChannelPublishingJmsMessageListenerTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Nms.Tests/Nms/Config/DefaultConfigurationTests.cs
+++ b/test/Spring/Spring.Integration.Nms.Tests/Nms/Config/DefaultConfigurationTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Nms.Tests/Nms/Config/NmsInboundChannelAdapterParserTests.cs
+++ b/test/Spring/Spring.Integration.Nms.Tests/Nms/Config/NmsInboundChannelAdapterParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Nms.Tests/Nms/Config/NmsInboundGatewayParserTests.cs
+++ b/test/Spring/Spring.Integration.Nms.Tests/Nms/Config/NmsInboundGatewayParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Nms.Tests/Nms/Config/NmsOutboundChannelAdapterParserTests.cs
+++ b/test/Spring/Spring.Integration.Nms.Tests/Nms/Config/NmsOutboundChannelAdapterParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Nms.Tests/Nms/Config/NmsOutboundGatewayParserTests.cs
+++ b/test/Spring/Spring.Integration.Nms.Tests/Nms/Config/NmsOutboundGatewayParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Nms.Tests/Nms/Config/TestMessageConverter.cs
+++ b/test/Spring/Spring.Integration.Nms.Tests/Nms/Config/TestMessageConverter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Nms.Tests/Nms/Config/TestNmsHeaderMapper.cs
+++ b/test/Spring/Spring.Integration.Nms.Tests/Nms/Config/TestNmsHeaderMapper.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Nms.Tests/Nms/DefaultNmsHeaderMapperTests.cs
+++ b/test/Spring/Spring.Integration.Nms.Tests/Nms/DefaultNmsHeaderMapperTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Nms.Tests/Nms/NmsTestUtils.cs
+++ b/test/Spring/Spring.Integration.Nms.Tests/Nms/NmsTestUtils.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Nms.Tests/Nms/StubConnection.cs
+++ b/test/Spring/Spring.Integration.Nms.Tests/Nms/StubConnection.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Nms.Tests/Nms/StubConsumer.cs
+++ b/test/Spring/Spring.Integration.Nms.Tests/Nms/StubConsumer.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Nms.Tests/Nms/StubDestination.cs
+++ b/test/Spring/Spring.Integration.Nms.Tests/Nms/StubDestination.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Nms.Tests/Nms/StubMessageConverter.cs
+++ b/test/Spring/Spring.Integration.Nms.Tests/Nms/StubMessageConverter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Nms.Tests/Nms/StubProducer.cs
+++ b/test/Spring/Spring.Integration.Nms.Tests/Nms/StubProducer.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Nms.Tests/Nms/StubSession.cs
+++ b/test/Spring/Spring.Integration.Nms.Tests/Nms/StubSession.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Nms.Tests/Nms/StubTextMessage.cs
+++ b/test/Spring/Spring.Integration.Nms.Tests/Nms/StubTextMessage.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Nms.Tests/Nms/ThreadPerTaskExecutor.cs
+++ b/test/Spring/Spring.Integration.Nms.Tests/Nms/ThreadPerTaskExecutor.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Nms.Tests/Spring.Integration.Nms.Tests.dll.config
+++ b/test/Spring/Spring.Integration.Nms.Tests/Spring.Integration.Nms.Tests.dll.config
@@ -6,7 +6,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Tests/Channel/ChannelPurgerTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Channel/ChannelPurgerTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,7 +32,7 @@ using Spring.Integration.Message;
 namespace Spring.Integration.Tests.Channel
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class ChannelPurgerTests
     {

--- a/test/Spring/Spring.Integration.Tests/Channel/Config/ChannelParserTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Channel/Config/ChannelParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -39,7 +39,7 @@ using Spring.Threading;
 namespace Spring.Integration.Tests.Channel.Config
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class ChannelParserTests
     {

--- a/test/Spring/Spring.Integration.Tests/Channel/Config/DirectChannelParserTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Channel/Config/DirectChannelParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,7 +32,7 @@ using Spring.Objects.Factory.Xml;
 namespace Spring.Integration.Tests.Channel.Config
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class DirectChannelParserTests
     {

--- a/test/Spring/Spring.Integration.Tests/Channel/Config/RendezvousChannelParserTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Channel/Config/RendezvousChannelParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,7 +32,7 @@ using Spring.Objects.Factory.Xml;
 namespace Spring.Integration.Tests.Channel.Config
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class RendezvousChannelParserTests
     {

--- a/test/Spring/Spring.Integration.Tests/Channel/Config/TestSource.cs
+++ b/test/Spring/Spring.Integration.Tests/Channel/Config/TestSource.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ using Spring.Integration.Message;
 namespace Spring.Integration.Tests.Channel.Config
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class TestSource : IMessageSource
     {
         private readonly string _text;

--- a/test/Spring/Spring.Integration.Tests/Channel/Config/TestTransformer.cs
+++ b/test/Spring/Spring.Integration.Tests/Channel/Config/TestTransformer.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +33,7 @@ namespace Spring.Integration.Tests.Channel.Config
     /// when either sending-to or receiving-from a channel.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class TestTransformer : ITransformer
     {
         public IMessage Transform(IMessage message)

--- a/test/Spring/Spring.Integration.Tests/Channel/Config/ThreadLocalChannelParserTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Channel/Config/ThreadLocalChannelParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ using Spring.Integration.Tests.Util;
 namespace Spring.Integration.Tests.Channel.Config
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class ThreadLocalChannelParserTests
     {

--- a/test/Spring/Spring.Integration.Tests/Channel/DirectChannelTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Channel/DirectChannelTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +33,7 @@ using Spring.Threading;
 namespace Spring.Integration.Tests.Channel
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class DirectChannelTests
     {

--- a/test/Spring/Spring.Integration.Tests/Channel/Interceptor/ChannelInterceptorTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Channel/Interceptor/ChannelInterceptorTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +33,7 @@ using Spring.Threading.AtomicTypes;
 namespace Spring.Integration.Tests.Channel.Interceptor
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class ChannelInterceptorTests
     {

--- a/test/Spring/Spring.Integration.Tests/Channel/Interceptor/MessageSelectingInterceptorTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Channel/Interceptor/MessageSelectingInterceptorTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +33,7 @@ using Spring.Threading.AtomicTypes;
 namespace Spring.Integration.Tests.Channel.Interceptor
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class MessageSelectingInterceptorTests
     {

--- a/test/Spring/Spring.Integration.Tests/Channel/Interceptor/WireTapTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Channel/Interceptor/WireTapTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +33,7 @@ using Spring.Integration.Selector;
 namespace Spring.Integration.Tests.Channel.Interceptor
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class WireTapTests
     {

--- a/test/Spring/Spring.Integration.Tests/Channel/MapBasedChannelResolverTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Channel/MapBasedChannelResolverTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +30,7 @@ using Spring.Integration.Core;
 namespace Spring.Integration.Tests.Channel
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class MapBasedChannelResolverTests
     {

--- a/test/Spring/Spring.Integration.Tests/Channel/MessageChannelTemplateTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Channel/MessageChannelTemplateTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Tests/Channel/MessagePayloadTestComparator.cs
+++ b/test/Spring/Spring.Integration.Tests/Channel/MessagePayloadTestComparator.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Tests/Channel/ObjectFactoryChannelResolverTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Channel/ObjectFactoryChannelResolverTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +30,7 @@ using Spring.Integration.Core;
 namespace Spring.Integration.Tests.Channel
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class ObjectFactoryChannelResolverTests
     {

--- a/test/Spring/Spring.Integration.Tests/Channel/PriorityChannelTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Channel/PriorityChannelTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,7 +32,7 @@ using Spring.Integration.Message;
 namespace Spring.Integration.Tests.Channel
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class PriorityChannelTests
     {

--- a/test/Spring/Spring.Integration.Tests/Channel/QueueChannelTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Channel/QueueChannelTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -38,7 +38,7 @@ using Spring.Threading.Execution;
 namespace Spring.Integration.Tests.Channel
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class QueueChannelTests
     {

--- a/test/Spring/Spring.Integration.Tests/Channel/TestChannelResolver.cs
+++ b/test/Spring/Spring.Integration.Tests/Channel/TestChannelResolver.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ using Spring.Integration.Util;
 namespace Spring.Integration.Tests.Channel
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class TestChannelResolver : IChannelResolver
     {

--- a/test/Spring/Spring.Integration.Tests/Channel/ThreadLocalChannelTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Channel/ThreadLocalChannelTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ using Spring.Integration.Message;
 namespace Spring.Integration.Tests.Channel
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class ThreadLocalChannelTests
     {

--- a/test/Spring/Spring.Integration.Tests/Config/Adder.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/Adder.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ using System.Collections.Generic;
 namespace Spring.Integration.Tests.Config
 {
     /// <author>Marius Bogoevici</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class Adder
     {
         // TODO this should be IList<long> but then we need complete generic channels. problem is here MethodListMethodAdapter.ExtractPayloadFromMessages

--- a/test/Spring/Spring.Integration.Tests/Config/AggregatorParserTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/AggregatorParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -40,7 +40,7 @@ namespace Spring.Integration.Tests.Config
 {
     /// <author>Marius Bogoevici</author>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class AggregatorParserTests
     {

--- a/test/Spring/Spring.Integration.Tests/Config/ChainParserTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/ChainParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,7 +34,7 @@ using Spring.Testing.NUnit;
 namespace Spring.Integration.Tests.Config
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     //@ContextConfiguration
     public class ChainParserTests : AbstractSpringContextTests

--- a/test/Spring/Spring.Integration.Tests/Config/ChannelAdapterParserTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/ChannelAdapterParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,7 +36,7 @@ using Spring.Testing.NUnit;
 namespace Spring.Integration.Tests.Config
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     //@ContextConfiguration
     public class ChannelAdapterParserTests : AbstractSpringContextTests

--- a/test/Spring/Spring.Integration.Tests/Config/EndpointParserTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/EndpointParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,7 +32,7 @@ using Spring.Integration.Tests.Util;
 namespace Spring.Integration.Tests.Config
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class EndpointParserTests
     {

--- a/test/Spring/Spring.Integration.Tests/Config/FilterParserTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/FilterParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -35,7 +35,7 @@ using Spring.Util;
 namespace Spring.Integration.Tests.Config
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     //@ContextConfiguration
     public class FilterParserTests

--- a/test/Spring/Spring.Integration.Tests/Config/MaxValueCompletionStrategy.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/MaxValueCompletionStrategy.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Tests/Config/MessageBusParserTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/MessageBusParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +33,7 @@ namespace Spring.Integration.Tests.Config
 {
     /// <author>Mark Fisher</author>
     /// <author>Marius Bogoevici</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class MessageBusParserTests
     {

--- a/test/Spring/Spring.Integration.Tests/Config/PublishSubscribeChannelParserTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/PublishSubscribeChannelParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -39,7 +39,7 @@ using Spring.Util;
 namespace Spring.Integration.Tests.Config
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class PublishSubscribeChannelParserTests
     {

--- a/test/Spring/Spring.Integration.Tests/Config/ResequencerParserTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/ResequencerParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,7 +36,7 @@ using Spring.Integration.Tests.Util;
 namespace Spring.Integration.Tests.Config
 {
     /// <author>Marius Bogoevici</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class ResequencerParserTests
     {

--- a/test/Spring/Spring.Integration.Tests/Config/SelectorChainParserTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/SelectorChainParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,7 +32,7 @@ using Spring.Integration.Tests.Util;
 namespace Spring.Integration.Tests.Config
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class SelectorChainParserTests
     {

--- a/test/Spring/Spring.Integration.Tests/Config/ServiceActivatorAnnotationPostProcessorTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/ServiceActivatorAnnotationPostProcessorTests.cs
@@ -7,7 +7,7 @@
 // * you may not use this file except in compliance with the License.
 // * You may obtain a copy of the License at
 // *
-// *      http://www.apache.org/licenses/LICENSE-2.0
+// *      https://www.apache.org/licenses/LICENSE-2.0
 // *
 // * Unless required by applicable law or agreed to in writing, software
 // * distributed under the License is distributed on an "AS IS" BASIS,
@@ -35,7 +35,7 @@
 
 //namespace Spring.Integration.Tests.Config {
 //    /// <author>Mark Fisher</author>
-//    /// <author>Andreas Döhring (.NET)</author>
+//    /// <author>Andreas Dï¿½hring (.NET)</author>
 //    [TestFixture]
 //public class ServiceActivatorAnnotationPostProcessorTests {
 

--- a/test/Spring/Spring.Integration.Tests/Config/StubMessageSelector.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/StubMessageSelector.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ using Spring.Objects.Factory;
 namespace Spring.Integration.Tests.Config
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class StubMessageSelector : IMessageSelector, IObjectNameAware
     {
         private string _objectName;

--- a/test/Spring/Spring.Integration.Tests/Config/StubTaskScheduler.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/StubTaskScheduler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ using Spring.Threading.Future;
 namespace Spring.Integration.Tests.Config
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class StubTaskScheduler : ITaskScheduler
     {
         public IScheduledFuture<object> Schedule(IRunnable task, ITrigger trigger)

--- a/test/Spring/Spring.Integration.Tests/Config/TestAggregatorObject.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/TestAggregatorObject.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,7 +32,7 @@ using Spring.Integration.Message;
 namespace Spring.Integration.Tests.Config
 {
     /// <author>Marius Bogoevici</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class TestAggregatorObject
     {
         // TODO private final ConcurrentMap<Object, Message<?>> aggregatedMessages = new ConcurrentHashMap<object, IMessage>();

--- a/test/Spring/Spring.Integration.Tests/Config/TestChannelInterceptor.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/TestChannelInterceptor.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ using Spring.Threading.AtomicTypes;
 namespace Spring.Integration.Tests.Config
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class TestChannelInterceptor : ChannelInterceptorAdapter
     {
         private readonly AtomicInteger _sendCount = new AtomicInteger();

--- a/test/Spring/Spring.Integration.Tests/Config/TestCompletionStrategy.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/TestCompletionStrategy.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +30,7 @@ using Spring.Integration.Core;
 namespace Spring.Integration.Tests.Config
 {
     /// <author>Marius Bogoevici</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class TestCompletionStrategy : ICompletionStrategy
     {
         public bool IsComplete(IList<IMessage> messages)

--- a/test/Spring/Spring.Integration.Tests/Config/TestConsumer.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/TestConsumer.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ using Spring.Integration.Message;
 namespace Spring.Integration.Tests.Config
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class TestConsumer : IMessageHandler
     {
         private volatile IMessage _lastMessage;

--- a/test/Spring/Spring.Integration.Tests/Config/TestErrorHandler.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/TestErrorHandler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ using Spring.Util;
 namespace Spring.Integration.Tests.Config
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class TestErrorHandler : IErrorHandler
     {
         private volatile Exception _lastError;

--- a/test/Spring/Spring.Integration.Tests/Config/TestHandler.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/TestHandler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +30,7 @@ using Spring.Threading;
 namespace Spring.Integration.Tests.Config
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class TestHandler
     {
         private string _messageString;

--- a/test/Spring/Spring.Integration.Tests/Config/TestObject.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/TestObject.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ using Spring.Threading;
 namespace Spring.Integration.Tests.Config
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class TestObject
     {
         private string _message;

--- a/test/Spring/Spring.Integration.Tests/Config/TestSelector.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/TestSelector.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ using Spring.Integration.Selector;
 namespace Spring.Integration.Tests.Config
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class TestSelector : IMessageSelector
     {
         private readonly bool _accept;

--- a/test/Spring/Spring.Integration.Tests/Config/WireTapParserTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/WireTapParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,7 +36,7 @@ using Spring.Integration.Tests.Util;
 namespace Spring.Integration.Tests.Config
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class WireTapParserTests
     {

--- a/test/Spring/Spring.Integration.Tests/Config/Xml/BridgeParserTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/Xml/BridgeParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +33,7 @@ using Spring.Integration.Tests.Util;
 namespace Spring.Integration.Tests.Config.Xml
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     //@ContextConfiguration
     public class BridgeParserTests

--- a/test/Spring/Spring.Integration.Tests/Config/Xml/GatewayParserTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/Xml/GatewayParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -35,7 +35,7 @@ using Spring.Threading.Execution;
 namespace Spring.Integration.Tests.Config.Xml
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class GatewayParserTests
     {

--- a/test/Spring/Spring.Integration.Tests/Config/Xml/ObjectToStringTransformerParserTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/Xml/ObjectToStringTransformerParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,7 +34,7 @@ using Spring.Integration.Tests.Util;
 namespace Spring.Integration.Tests.Config.Xml
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     //@ContextConfiguration
         //@RunWith(SpringJUnit4ClassRunner.class)

--- a/test/Spring/Spring.Integration.Tests/Config/Xml/PayloadDeserializingTransformerParserTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/Xml/PayloadDeserializingTransformerParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,7 +36,7 @@ using Spring.Integration.Transformer;
 namespace Spring.Integration.Tests.Config.Xml
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     //@ContextConfiguration
         //@RunWith(SpringJUnit4ClassRunner.class)

--- a/test/Spring/Spring.Integration.Tests/Config/Xml/PayloadSerializingTransformerParserTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/Xml/PayloadSerializingTransformerParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -37,7 +37,7 @@ using Spring.Integration.Transformer;
 namespace Spring.Integration.Tests.Config.Xml
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     //@ContextConfiguration
         //@RunWith(SpringJUnit4ClassRunner.class)

--- a/test/Spring/Spring.Integration.Tests/Config/Xml/PollerParserTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/Xml/PollerParserTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +33,7 @@ using Spring.Objects.Factory;
 namespace Spring.Integration.Tests.Config.Xml
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class PollerParserTests
     {

--- a/test/Spring/Spring.Integration.Tests/Config/Xml/TestAdviceBean.cs
+++ b/test/Spring/Spring.Integration.Tests/Config/Xml/TestAdviceBean.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ using Spring.Aop;
 namespace Spring.Integration.Tests.Config.Xml
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class TestAdviceObject : IMethodBeforeAdvice
     {
         private readonly int _id;

--- a/test/Spring/Spring.Integration.Tests/Core/MessageHeadersTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Core/MessageHeadersTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Tests/Endpoint/CorrelationIdTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Endpoint/CorrelationIdTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Tests/Endpoint/PollingConsumerEndpointTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Endpoint/PollingConsumerEndpointTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Tests/Endpoint/PollingEndpointErrorHandlingTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Endpoint/PollingEndpointErrorHandlingTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Tests/Endpoint/PollingEndpointStub.cs
+++ b/test/Spring/Spring.Integration.Tests/Endpoint/PollingEndpointStub.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Tests/Endpoint/ReturnAddressTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Endpoint/ReturnAddressTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Tests/Endpoint/ServiceActivatorEndpointTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Endpoint/ServiceActivatorEndpointTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Tests/Endpoint/TestObject.cs
+++ b/test/Spring/Spring.Integration.Tests/Endpoint/TestObject.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Tests/Gateway/GatewayProxyFactoryObjectTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Gateway/GatewayProxyFactoryObjectTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Tests/Gateway/ITestService.cs
+++ b/test/Spring/Spring.Integration.Tests/Gateway/ITestService.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ using Spring.Integration.Core;
 namespace Spring.Integration.Tests.Gateway
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public interface ITestService
     {
         string RequestReply(string input);

--- a/test/Spring/Spring.Integration.Tests/Gateway/SimpleMessagingGatewayTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Gateway/SimpleMessagingGatewayTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,7 +36,7 @@ using Spring.Integration.Tests.Util;
 namespace Spring.Integration.Tests.Gateway
 {
     /// <author>Iwein Fuld</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class SimpleMessagingGatewayTests
     {

--- a/test/Spring/Spring.Integration.Tests/Gateway/TestChannelInterceptor.cs
+++ b/test/Spring/Spring.Integration.Tests/Gateway/TestChannelInterceptor.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ using Spring.Threading.AtomicTypes;
 namespace Spring.Integration.Tests.Gateway
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class TestChannelInterceptor : ChannelInterceptorAdapter
     {
         private readonly AtomicInteger _sentCount = new AtomicInteger();

--- a/test/Spring/Spring.Integration.Tests/Gateway/TestHandler.cs
+++ b/test/Spring/Spring.Integration.Tests/Gateway/TestHandler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ using Spring.Integration.Core;
 namespace Spring.Integration.Tests.Gateway
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public class TestHandler
     {
         public string Handle(IMessage message)

--- a/test/Spring/Spring.Integration.Tests/Handler/HandlerMethodInheritanceTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Handler/HandlerMethodInheritanceTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Tests/Handler/MessageHandlerChainTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Handler/MessageHandlerChainTests.cs
@@ -7,7 +7,7 @@
 // * you may not use this file except in compliance with the License.
 // * You may obtain a copy of the License at
 // *
-// *      http://www.apache.org/licenses/LICENSE-2.0
+// *      https://www.apache.org/licenses/LICENSE-2.0
 // *
 // * Unless required by applicable law or agreed to in writing, software
 // * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Tests/Handler/MessageMappingMethodInvokerTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Handler/MessageMappingMethodInvokerTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Tests/Handler/MethodInvokingMessageHandlerTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Handler/MethodInvokingMessageHandlerTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Tests/Handler/PayloadTypeMatchingHandlerMethodResolverTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Handler/PayloadTypeMatchingHandlerMethodResolverTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Tests/Handler/PayloadTypeMatchingHandlerMethodResolverWithMessageParameterTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Handler/PayloadTypeMatchingHandlerMethodResolverWithMessageParameterTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Tests/Handler/StaticHandlerMethodResolverTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Handler/StaticHandlerMethodResolverTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Tests/Message/MessageBuilderTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Message/MessageBuilderTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Integration.Tests/Message/MessageTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Message/MessageTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +30,7 @@ using Spring.Integration.Message.Generic;
 namespace Spring.Integration.Tests.Message
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class MessageTests
     {

--- a/test/Spring/Spring.Integration.Tests/Message/MethodInvokingSourceTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Message/MethodInvokingSourceTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ using Spring.Integration.Message;
 namespace Spring.Integration.Tests.Message
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class MethodInvokingSourceTests
     {

--- a/test/Spring/Spring.Integration.Tests/Message/MethodParameterMessageMapperFromMessageTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Message/MethodParameterMessageMapperFromMessageTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,7 +34,7 @@ using Spring.Util;
 namespace Spring.Integration.Tests.Message
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class MethodParameterMessageMapperFromMessageTests
     {

--- a/test/Spring/Spring.Integration.Tests/Message/MethodParameterMessageMapperInitializationTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Message/MethodParameterMessageMapperInitializationTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ using Spring.Integration.Message;
 namespace Spring.Integration.Tests.Message
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class MethodParameterMessageMapperInitializationTests
     {

--- a/test/Spring/Spring.Integration.Tests/Message/MethodParameterMessageMapperToMessageTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Message/MethodParameterMessageMapperToMessageTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +33,7 @@ using Spring.Integration.Message;
 namespace Spring.Integration.Tests.Message
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class MethodParameterMessageMapperToMessageTests
     {

--- a/test/Spring/Spring.Integration.Tests/Message/Selector/PayloadTypeSelectorTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Message/Selector/PayloadTypeSelectorTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,7 +32,7 @@ using Spring.Integration.Selector;
 namespace Spring.Integration.Tests.Message.Selector
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class PayloadTypeSelectorTests
     {

--- a/test/Spring/Spring.Integration.Tests/Message/Selector/UnexpiredMessageSelectorTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Message/Selector/UnexpiredMessageSelectorTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ using Spring.Integration.Selector;
 namespace Spring.Integration.Tests.Message.Selector
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class UnexpiredMessageSelectorTests
     {

--- a/test/Spring/Spring.Integration.Tests/Message/TestHandlers.cs
+++ b/test/Spring/Spring.Integration.Tests/Message/TestHandlers.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,7 +24,7 @@ namespace Spring.Integration.Tests.Message
     /// Factory for handler beans that are useful for testing.
     /// </summary>
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class TestHandlers
     {
         ///**

--- a/test/Spring/Spring.Integration.Tests/Util/DefaultMethodInvokerTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Util/DefaultMethodInvokerTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ using Spring.Integration.Util;
 namespace Spring.Integration.Tests.Util
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class DefaultMethodInvokerTests
     {

--- a/test/Spring/Spring.Integration.Tests/Util/NameResolvingMethodInvokerTests.cs
+++ b/test/Spring/Spring.Integration.Tests/Util/NameResolvingMethodInvokerTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ using Spring.Integration.Util;
 
 namespace Spring.Integration.Tests.Util
 {
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     [TestFixture]
     public class NameResolvingMethodInvokerTests
     {

--- a/test/Spring/Spring.Integration.Tests/Util/TestUtils.cs
+++ b/test/Spring/Spring.Integration.Tests/Util/TestUtils.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -45,7 +45,7 @@ using Spring.Util;
 namespace Spring.Integration.Tests.Util
 {
     /// <author>Mark Fisher</author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     public abstract class TestUtils
     {
         public static IApplicationContext GetContext(params string[] files)


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 321 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).